### PR TITLE
Tarscpp arm

### DIFF
--- a/util/include/util/tc_atomic.h
+++ b/util/include/util/tc_atomic.h
@@ -137,10 +137,7 @@ public:
      */
     void inc_fast()
     {
-        __asm__ __volatile__(
-            TARS_LOCK "incl %0"
-            :"=m" (_value.counter)
-            :"m" (_value.counter));
+	__sync_add_and_fetch(&_value.counter,1);
     }
 
     /**
@@ -150,14 +147,7 @@ public:
      */
     bool dec_and_test()
     {
-        unsigned char c;
-
-        __asm__ __volatile__(
-            TARS_LOCK "decl %0; sete %1"
-            :"=m" (_value.counter), "=qm" (c)
-            :"m" (_value.counter) : "memory");
-
-        return c != 0;
+	return (0 == __sync_sub_and_fetch(&_value.counter,1));
     }
 
     /**
@@ -177,13 +167,7 @@ protected:
      */
     int add_and_return(int i)
     {
-        /* Modern 486+ processor */
-        int __i = i;
-        __asm__ __volatile__(
-            TARS_LOCK "xaddl %0, %1;"
-            :"=r"(i)
-            :"m"(_value.counter), "0"(i));
-        return i + __i;
+	return (__sync_add_and_fetch(&_value.counter,i));
     }
 
 protected:

--- a/util/src/tc_timeprovider.cpp
+++ b/util/src/tc_timeprovider.cpp
@@ -100,10 +100,7 @@ float TC_TimeProvider::cpuMHz()
 
 void TC_TimeProvider::setTsc(timeval& tt)
 {
-    uint32_t low    = 0;
-    uint32_t high   = 0;
-    rdtsc(low,high);
-    uint64_t current_tsc    = ((uint64_t)high << 32) | low;
+    uint64_t current_tsc    = rdtsc();
 
     uint64_t& last_tsc      = _tsc[!_buf_idx];
     timeval& last_tt        = _t[_buf_idx];
@@ -123,10 +120,7 @@ void TC_TimeProvider::setTsc(timeval& tt)
 
 void TC_TimeProvider::addTimeOffset(timeval& tt,const int &idx)
 {
-    uint32_t low    = 0;
-    uint32_t high   = 0;
-    rdtsc(low,high);
-    uint64_t current_tsc = ((uint64_t)high << 32) | low;
+    uint64_t current_tsc = rdtsc();
     int64_t t =  (int64_t)(current_tsc - _tsc[idx]);
     time_t offset =  (time_t)(t*_cpu_cycle);
     if(t < -1000 || offset > 1000000)//毫秒级别


### PR DESCRIPTION
1. Replace atomic x86 ASM code with GCC atomic-builtins.
2. Add arm equivalent high-precision counter instructions cntvct_el0 as x86's rtdsc