### PR TITLE
fix a bug that the method was not sorted by name when generate code from protobuf

### DIFF
--- a/tools/pb2tarscpp/CppGenCallback.cpp
+++ b/tools/pb2tarscpp/CppGenCallback.cpp
@@ -66,10 +66,18 @@ std::string GenPrxCallback(const ::google::protobuf::ServiceDescriptor* desc, in
     out += LineFeed(indent);
     out += LineFeed(indent);
 
-    for (int i = 0; i < desc->method_count(); ++i) {
-        auto method = desc->method(i);
-        out += GenCallbackMethod(method, pkg, indent);
-    }
+    //sort by method name
+	std::map<std::string, const ::google::protobuf::MethodDescriptor*> m_method;
+	for (int i = 0; i < desc->method_count(); ++i)
+	{
+		m_method[desc->method(i)->name()] = desc->method(i);
+	}
+
+	for(auto it = m_method.begin(); it != m_method.end(); ++it)
+	{
+		auto method = it->second;
+		out += GenCallbackMethod(method, pkg, indent);
+	}
 
     out += LineFeed(indent);
     out += LineFeed(indent);
@@ -86,8 +94,9 @@ std::string GenPrxCallback(const ::google::protobuf::ServiceDescriptor* desc, in
     out += "static ::std::string __all[] = ";
     out += "{";
     out += LineFeed(++indent);
-    for (int i = 0; i < desc->method_count(); ++i) {
-        auto method = desc->method(i);
+    for(auto it = m_method.begin(); it != m_method.end(); ++it)
+	{
+    	auto method = it->second;
         out += "\"" + method->name() + "\",";
         out += LineFeed(indent);
     }
@@ -99,8 +108,10 @@ std::string GenPrxCallback(const ::google::protobuf::ServiceDescriptor* desc, in
     out += "switch(r.first - __all)" + LineFeed(indent);
     out += "{";
     out += LineFeed(++indent);
-    for (int i = 0; i < desc->method_count(); ++i) {
-        auto method = desc->method(i);
+    int i = 0;
+    for(auto it = m_method.begin(); it != m_method.end(); ++it)
+	{
+    	auto method = it->second;
         out += LineFeed(indent);
         out += "case " + std::to_string((long long)i) + ":" + LineFeed(indent);
         out += "{" + LineFeed(++indent);
@@ -123,6 +134,8 @@ std::string GenPrxCallback(const ::google::protobuf::ServiceDescriptor* desc, in
 
         out += LineFeed(--indent);
         out += "}";
+
+        ++i;
     }
 
     // end switch

--- a/tools/pb2tarscpp/CppGenProxy.cpp
+++ b/tools/pb2tarscpp/CppGenProxy.cpp
@@ -81,15 +81,25 @@ std::string GenPrx(const ::google::protobuf::ServiceDescriptor* desc, int indent
     out += "public:";
     out += LineFeed(++indent);
     out += "typedef std::map<std::string, std::string> TARS_CONTEXT;" + LineFeed(indent);
-    // gen methods
-    for (int i = 0; i < desc->method_count(); ++i) {
-        auto method = desc->method(i);
-        out += LineFeed(indent);
-        // sync method call
-        out += GenSyncCall(method, pkg, indent);
-        // async method call
-        out += GenAsyncCall(method, name, pkg, indent);
-    }
+
+    //sort by method name
+	std::map<std::string, const ::google::protobuf::MethodDescriptor*> m_method;
+	for (int i = 0; i < desc->method_count(); ++i)
+	{
+		m_method[desc->method(i)->name()] = desc->method(i);
+	}
+
+	// gen methods
+	for(auto it = m_method.begin(); it != m_method.end(); ++it)
+	{
+		auto method = it->second;
+		out += LineFeed(indent);
+		// sync method call
+		out += GenSyncCall(method, pkg, indent);
+		// async method call
+		out += GenAsyncCall(method, name, pkg, indent);
+	}
+
 
     // hash call
     out += LineFeed(indent);

--- a/tools/pb2tarscpp/CppGenServant.cpp
+++ b/tools/pb2tarscpp/CppGenServant.cpp
@@ -84,8 +84,16 @@ std::string GenServant(const ::google::protobuf::ServiceDescriptor* desc, int in
     out += "virtual ~" + servant + "() {}";
     out += LineFeed(indent);
 
-    for (int i = 0; i < desc->method_count(); ++i) {
-        out += GenMethods(desc->method(i), pkg, indent);
+    //sort by method name
+    std::map<std::string, const ::google::protobuf::MethodDescriptor*> m_method;
+    for (int i = 0; i < desc->method_count(); ++i)
+    {
+    	m_method[desc->method(i)->name()] = desc->method(i);
+    }
+
+    for(auto it = m_method.begin(); it != m_method.end(); ++it)
+    {
+    	out += GenMethods(it->second, pkg, indent);
     }
 
     // gen onDispatch
@@ -97,10 +105,11 @@ std::string GenServant(const ::google::protobuf::ServiceDescriptor* desc, int in
     out += "static ::std::string __all[] = ";
     out += "{";
     out += LineFeed(++indent);
-    for (int i = 0; i < desc->method_count(); ++i) {
-        auto method = desc->method(i);
-        out += "\"" + method->name() + "\",";
-        out += LineFeed(indent);
+    for(auto it = m_method.begin(); it != m_method.end(); ++it)
+    {
+    	auto method = it->second;
+    	out += "\"" + method->name() + "\",";
+		out += LineFeed(indent);
     }
     out += LineFeed(--indent);
     out += "};";
@@ -113,14 +122,18 @@ std::string GenServant(const ::google::protobuf::ServiceDescriptor* desc, int in
     out += LineFeed(indent);
     out += "{";
     out += LineFeed(++indent);
-    for (int i = 0; i < desc->method_count(); ++i) {
-        auto method = desc->method(i);
-        out += LineFeed(indent);
-        out += "case " + std::to_string((long long)i) + ":";
-        out += LineFeed(indent);
+    int i = 0;
+    for(auto it = m_method.begin(); it != m_method.end(); ++it)
+	{
+    	auto method = it->second;
+    	out += LineFeed(indent);
+		out += "case " + std::to_string((long long)i) + ":";
+		out += LineFeed(indent);
 
-        out += GenDispatchCase(method, pkg, indent);
-    }
+		out += GenDispatchCase(method, pkg, indent);
+
+		++i;
+	}
 
     // end switch
     out += LineFeed(--indent);


### PR DESCRIPTION
bug修复：从pb协议生成 xx.tars.h文件时，方法名未做排序，导致rpc调用时不能调用到正确的方法