### PR TITLE
Fix incorrect namespace generated by pb2tarscpp

### DIFF
--- a/tools/pb2tarscpp/CppGenCallback.cpp
+++ b/tools/pb2tarscpp/CppGenCallback.cpp
@@ -14,7 +14,7 @@ static std::string GenCallbackMethod(const ::google::protobuf::MethodDescriptor*
     std::string out;
     out.reserve(8 * 1024);
 
-    out = "virtual void callback_" + method->name() + "(const " + pkg + "::" + method->output_type()->name() + "& ret)" + LineFeed(indent);
+    out = "virtual void callback_" + method->name() + "(const " + ToCppNamespace(method->output_type()->full_name()) + "& ret)" + LineFeed(indent);
     out += "{ throw std::runtime_error(\"callback_" + method->name() + " override incorrect.\"); }" + LineFeed(indent);
 
     out += "virtual void callback_" + method->name() + "_exception(tars::Int32 ret)" + LineFeed(indent);
@@ -121,7 +121,7 @@ std::string GenPrxCallback(const ::google::protobuf::ServiceDescriptor* desc, in
         out += "return msg->response.iRet;" + LineFeed(--indent) + "}";
     
         out += LineFeed(indent);
-        out += pkg + "::" + method->output_type()->name() + " _ret;" + LineFeed(indent);
+        out += ToCppNamespace(method->output_type()->full_name()) + " _ret;" + LineFeed(indent);
         out += "_ret.ParseFromArray(msg->response.sBuffer.data(), msg->response.sBuffer.size());" + LineFeed(indent);
         out += "CallbackThreadData * pCbtd = CallbackThreadData::getData();" + LineFeed(indent);
         out += "assert(pCbtd != NULL);" + LineFeed(indent);

--- a/tools/pb2tarscpp/CppGenProxy.cpp
+++ b/tools/pb2tarscpp/CppGenProxy.cpp
@@ -16,8 +16,8 @@ static std::string GenSyncCall(const ::google::protobuf::MethodDescriptor* metho
     std::string out;
     out.reserve(8 * 1024);
 
-    out += pkg + "::" + method->output_type()->name() + " " + method->name() + "(const " +
-           pkg + "::" + method->input_type()->name() + "& req, const std::map<std::string, std::string>& context = TARS_CONTEXT(), " +
+    out += ToCppNamespace(method->output_type()->full_name()) + " " + method->name() + "(const " +
+           ToCppNamespace(method->input_type()->full_name()) + "& req, const std::map<std::string, std::string>& context = TARS_CONTEXT(), " +
            "std::map<std::string, std::string>* pResponseContext = NULL)";
     out += LineFeed(indent);
     out += "{" + LineFeed(++indent);
@@ -32,7 +32,7 @@ static std::string GenSyncCall(const ::google::protobuf::MethodDescriptor* metho
     out += "*pResponseContext = rep.context;" + LineFeed(--indent);
 
     out += LineFeed(indent);
-    out += pkg + "::" + method->output_type()->name() + " _ret;" + LineFeed(indent);
+    out += ToCppNamespace(method->output_type()->full_name()) + " _ret;" + LineFeed(indent);
     out += "_ret.ParseFromArray(rep.sBuffer.data(), rep.sBuffer.size());" + LineFeed(indent) + 
            "return _ret;";
     out += LineFeed(--indent) + "}";
@@ -49,8 +49,8 @@ static std::string GenAsyncCall(const ::google::protobuf::MethodDescriptor* meth
     std::string out;
     out.reserve(8 * 1024);
 
-    out += "void async_" + method->name() + "(" + name + "PrxCallbackPtr callback, const " + pkg + "::" + 
-           method->input_type()->name() + "& req, const std::map<std::string, std::string>& context = TARS_CONTEXT())" + LineFeed(indent);
+    out += "void async_" + method->name() + "(" + name + "PrxCallbackPtr callback, const " +
+           ToCppNamespace(method->input_type()->full_name()) + "& req, const std::map<std::string, std::string>& context = TARS_CONTEXT())" + LineFeed(indent);
     out += "{" + LineFeed(++indent);
     out += "std::string _os;" + LineFeed(indent) +
            "req.SerializeToString(&_os);" + LineFeed(indent) +

--- a/tools/pb2tarscpp/CppGenServant.cpp
+++ b/tools/pb2tarscpp/CppGenServant.cpp
@@ -16,9 +16,9 @@ static std::string GenMethods(const ::google::protobuf::MethodDescriptor* method
     std::string out;
     out.reserve(8 * 1024);
 
-    out += "virtual " + pkg + "::" + method->output_type()->name() + " " + method->name() +
-           "(const " + pkg + "::" + method->input_type()->name() + "& , tars::TarsCurrentPtr current) = 0;" + LineFeed(indent);
-    out += "static void async_response_" + method->name() + "(tars::TarsCurrentPtr current, const " + pkg + "::" + method->output_type()->name() + "&_ret)" + LineFeed(indent);
+    out += "virtual " + ToCppNamespace(method->output_type()->full_name()) + " " + method->name() +
+           "(const " + ToCppNamespace(method->input_type()->full_name()) + "& , tars::TarsCurrentPtr current) = 0;" + LineFeed(indent);
+    out += "static void async_response_" + method->name() + "(tars::TarsCurrentPtr current, const " + ToCppNamespace(method->output_type()->full_name()) + "&_ret)" + LineFeed(indent);
     out += "{" + LineFeed(++indent);
     out += "std::string _os;" + LineFeed(indent) +
            " _ret.SerializeToString(&_os);" + LineFeed(indent) + 
@@ -43,11 +43,11 @@ static std::string GenDispatchCase(const ::google::protobuf::MethodDescriptor* m
            "_is.setBuffer(_current->getRequestBuffer());" + LineFeed(indent);
     out += LineFeed(indent);
 
-    out += pkg + "::" + method->input_type()->name() + " req;" + LineFeed(indent);
+    out += ToCppNamespace(method->input_type()->full_name()) + " req;" + LineFeed(indent);
     out += "req.ParseFromArray(&_current->getRequestBuffer()[0], _current->getRequestBuffer().size());" + LineFeed(indent);
     out += LineFeed(indent);
 
-    out += pkg + "::" + method->output_type()->name() + " _ret = " + method->name() + "(req, _current);" +  LineFeed(indent);
+    out += ToCppNamespace(method->output_type()->full_name()) + " _ret = " + method->name() + "(req, _current);" +  LineFeed(indent);
     out += "if (_current->isResponse())" + LineFeed(indent);
     out += "{" + LineFeed(++indent);
     out += "std::string _os;" + LineFeed(indent);

--- a/tools/pb2tarscpp/CppPbUtils.cpp
+++ b/tools/pb2tarscpp/CppPbUtils.cpp
@@ -37,3 +37,15 @@ std::string LineFeed(int indent) {
     return data;
 }
 
+std::string ToCppNamespace(const std::string& name) {
+    std::string ret;
+    for(auto &c: name) {
+        if(c == '.') {
+            ret += "::";
+        } else {
+            ret += c;
+        }
+    }
+    return ret;
+}
+

--- a/tools/pb2tarscpp/CppPbUtils.h
+++ b/tools/pb2tarscpp/CppPbUtils.h
@@ -14,3 +14,6 @@ extern const std::string kIndent;
 
 std::string LineFeed(int indent = 0) ;
 
+
+std::string ToCppNamespace(const std::string& name);
+


### PR DESCRIPTION
The namespace of class from the outside package was current namespace rather than the original namespace generated in *.tars.h
Fix by replacing it with the original namespace.