### PR TITLE
fix:  p->getType() cause coredump when p is null

### DIFF
--- a/servant/tup/TarsJson.h
+++ b/servant/tup/TarsJson.h
@@ -26,7 +26,7 @@ public:
         else if (isRequire)
         {
             char s[128];
-            snprintf(s, sizeof(s), "read 'Bool' type mismatch, get type: %d.", p->getType());
+            snprintf(s, sizeof(s), "read 'Bool' type mismatch, get type: %d.", (p.get() ? p->getType() : 0));
             throw TC_Json_Exception(s);
         }
     }
@@ -40,7 +40,7 @@ public:
         else if (isRequire)
         {
             char s[128];
-            snprintf(s, sizeof(s), "read 'Char' type mismatch, get type: %d.", p->getType());
+            snprintf(s, sizeof(s), "read 'Char' type mismatch, get type: %d.", (p.get() ? p->getType() : 0));
             throw TC_Json_Exception(s);
         }
     }
@@ -54,7 +54,7 @@ public:
         else if (isRequire)
         {
             char s[128];
-            snprintf(s, sizeof(s), "read 'Uint8' type mismatch, get type: %d.", p->getType());
+            snprintf(s, sizeof(s), "read 'Uint8' type mismatch, get type: %d.", (p.get() ? p->getType() : 0));
             throw TC_Json_Exception(s);
         }
     }
@@ -68,7 +68,7 @@ public:
         else if (isRequire)
         {
             char s[128];
-            snprintf(s, sizeof(s), "read 'Short' type mismatch, get type: %d.", p->getType());
+            snprintf(s, sizeof(s), "read 'Short' type mismatch, get type: %d.", (p.get() ? p->getType() : 0));
             throw TC_Json_Exception(s);
         }
     }
@@ -82,7 +82,7 @@ public:
         else if (isRequire)
         {
             char s[128];
-            snprintf(s, sizeof(s), "read 'Uint16' type mismatch, get type: %d.", p->getType());
+            snprintf(s, sizeof(s), "read 'Uint16' type mismatch, get type: %d.", (p.get() ? p->getType() : 0));
             throw TC_Json_Exception(s);
         }
     }
@@ -96,7 +96,7 @@ public:
         else if (isRequire)
         {
             char s[128];
-            snprintf(s, sizeof(s), "read 'Int32' type mismatch, get type: %d.", p->getType());
+            snprintf(s, sizeof(s), "read 'Int32' type mismatch, get type: %d.", (p.get() ? p->getType() : 0));
             throw TC_Json_Exception(s);
         }
     }
@@ -110,7 +110,7 @@ public:
         else if (isRequire)
         {
             char s[128];
-            snprintf(s, sizeof(s), "read 'UInt32' type mismatch, get type: %d.", p->getType());
+            snprintf(s, sizeof(s), "read 'UInt32' type mismatch, get type: %d.", (p.get() ? p->getType() : 0));
             throw TC_Json_Exception(s);
         }
     }
@@ -124,7 +124,7 @@ public:
         else if (isRequire)
         {
             char s[128];
-            snprintf(s, sizeof(s), "read 'Int64' type mismatch, get type: %d.", p->getType());
+            snprintf(s, sizeof(s), "read 'Int64' type mismatch, get type: %d.", (p.get() ? p->getType() : 0));
             throw TC_Json_Exception(s);
         }
     }
@@ -138,7 +138,7 @@ public:
         else if (isRequire)
         {
             char s[128];
-            snprintf(s, sizeof(s), "read 'Float' type mismatch, get type: %d.", p->getType());
+            snprintf(s, sizeof(s), "read 'Float' type mismatch, get type: %d.", (p.get() ? p->getType() : 0));
             throw TC_Json_Exception(s);
         }
     }
@@ -152,7 +152,7 @@ public:
         else if (isRequire)
         {
             char s[128];
-            snprintf(s, sizeof(s), "read 'Double' type mismatch, get type: %d.", p->getType());
+            snprintf(s, sizeof(s), "read 'Double' type mismatch, get type: %d.", (p.get() ? p->getType() : 0));
             throw TC_Json_Exception(s);
         }
     }
@@ -166,7 +166,7 @@ public:
         else if (isRequire)
         {
             char s[128];
-            snprintf(s, sizeof(s), "read 'string' type mismatch, get type: %d.", p->getType());
+            snprintf(s, sizeof(s), "read 'string' type mismatch, get type: %d.", (p.get() ? p->getType() : 0));
             throw TC_Json_Exception(s);
         }
     }
@@ -188,7 +188,7 @@ public:
         else if (isRequire)
         {
             char s[128];
-            snprintf(s, sizeof(s), "read 'char *' type mismatch, get type: %d.", p->getType());
+            snprintf(s, sizeof(s), "read 'char *' type mismatch, get type: %d.", (p.get() ? p->getType() : 0));
             throw TC_Json_Exception(s);
         }
     }
@@ -212,7 +212,7 @@ public:
         else if (isRequire)
         {
             char s[128];
-            snprintf(s, sizeof(s), "read 'map' type mismatch, get type: %d.", p->getType());
+            snprintf(s, sizeof(s), "read 'map' type mismatch, get type: %d.", (p.get() ? p->getType() : 0));
             throw TC_Json_Exception(s);
         }
     }
@@ -235,7 +235,7 @@ public:
         else if (isRequire)
         {
             char s[128];
-            snprintf(s, sizeof(s), "read 'map' type mismatch, get type: %d.", p->getType());
+            snprintf(s, sizeof(s), "read 'map' type mismatch, get type: %d.", (p.get() ? p->getType() : 0));
             throw TC_Json_Exception(s);
         }
     }
@@ -258,7 +258,7 @@ public:
         else if (isRequire)
         {
             char s[128];
-            snprintf(s, sizeof(s), "read 'map' type mismatch, get type: %d.", p->getType());
+            snprintf(s, sizeof(s), "read 'map' type mismatch, get type: %d.", (p.get() ? p->getType() : 0));
             throw TC_Json_Exception(s);
         }
     }
@@ -280,7 +280,7 @@ public:
         else if (isRequire)
         {
             char s[128];
-            snprintf(s, sizeof(s), "read 'map' type mismatch, get type: %d.", p->getType());
+            snprintf(s, sizeof(s), "read 'map' type mismatch, get type: %d.", (p.get() ? p->getType() : 0));
             throw TC_Json_Exception(s);
         }
     }
@@ -302,7 +302,7 @@ public:
         else if (isRequire)
         {
             char s[128];
-            snprintf(s, sizeof(s), "read 'map' type mismatch, get type: %d.", p->getType());
+            snprintf(s, sizeof(s), "read 'map' type mismatch, get type: %d.", (p.get() ? p->getType() : 0));
             throw TC_Json_Exception(s);
         }
     }
@@ -325,7 +325,7 @@ public:
         else if (isRequire)
         {
             char s[128];
-            snprintf(s, sizeof(s), "read 'map' type mismatch, get type: %d.", p->getType());
+            snprintf(s, sizeof(s), "read 'map' type mismatch, get type: %d.", (p.get() ? p->getType() : 0));
             throw TC_Json_Exception(s);
         }
     }
@@ -348,7 +348,7 @@ public:
         else if (isRequire)
         {
             char s[128];
-            snprintf(s, sizeof(s), "read 'map' type mismatch, get type: %d.", p->getType());
+            snprintf(s, sizeof(s), "read 'map' type mismatch, get type: %d.", (p.get() ? p->getType() : 0));
             throw TC_Json_Exception(s);
         }
     }
@@ -371,7 +371,7 @@ public:
         else if (isRequire)
         {
             char s[128];
-            snprintf(s, sizeof(s), "read 'map' type mismatch, get type: %d.", p->getType());
+            snprintf(s, sizeof(s), "read 'map' type mismatch, get type: %d.", (p.get() ? p->getType() : 0));
             throw TC_Json_Exception(s);
         }
     }
@@ -394,7 +394,7 @@ public:
         else if (isRequire)
         {
             char s[128];
-            snprintf(s, sizeof(s), "read 'map' type mismatch, get type: %d.", p->getType());
+            snprintf(s, sizeof(s), "read 'map' type mismatch, get type: %d.", (p.get() ? p->getType() : 0));
             throw TC_Json_Exception(s);
         }
     }
@@ -417,7 +417,7 @@ public:
         else if (isRequire)
         {
             char s[128];
-            snprintf(s, sizeof(s), "read 'map' type mismatch, get type: %d.", p->getType());
+            snprintf(s, sizeof(s), "read 'map' type mismatch, get type: %d.", (p.get() ? p->getType() : 0));
             throw TC_Json_Exception(s);
         }
     }
@@ -440,7 +440,7 @@ public:
         else if (isRequire)
         {
             char s[128];
-            snprintf(s, sizeof(s), "read 'map' type mismatch, get type: %d.", p->getType());
+            snprintf(s, sizeof(s), "read 'map' type mismatch, get type: %d.", (p.get() ? p->getType() : 0));
             throw TC_Json_Exception(s);
         }
     }
@@ -468,7 +468,7 @@ public:
         else if (isRequire)
         {
             char s[128];
-            snprintf(s, sizeof(s), "read 'vector' type mismatch, get type: %d.", p->getType());
+            snprintf(s, sizeof(s), "read 'vector' type mismatch, get type: %d.", (p.get() ? p->getType() : 0));
             throw TC_Json_Exception(s);
         }
     }
@@ -495,7 +495,7 @@ public:
         else if (isRequire)
         {
             char s[128];
-            snprintf(s, sizeof(s), "read 'T *' type mismatch, get type: %d.", p->getType());
+            snprintf(s, sizeof(s), "read 'T *' type mismatch, get type: %d.", (p.get() ? p->getType() : 0));
             throw TC_Json_Exception(s);
         }
     }
@@ -520,7 +520,7 @@ public:
         else if (isRequire)
         {
             char s[128];
-            snprintf(s, sizeof(s), "read 'Char' type mismatch, get type: %d.", p->getType());
+            snprintf(s, sizeof(s), "read 'Char' type mismatch, get type: %d.", (p.get() ? p->getType() : 0));
             throw TC_Json_Exception(s);
         }
     }

--- a/servant/tup/TarsXml.h
+++ b/servant/tup/TarsXml.h
@@ -29,7 +29,7 @@ public:
         else if (isRequire)
         {
             char s[128];
-            snprintf(s, sizeof(s), "read 'Bool' type mismatch, get type: %d.", p->getType());
+            snprintf(s, sizeof(s), "read 'Bool' type mismatch, get type: %d.", (p.get() ? p->getType() : 0));
             throw TC_Xml_Exception(s);
         }
     }
@@ -43,7 +43,7 @@ public:
         else if (isRequire)
         {
             char s[128];
-            snprintf(s, sizeof(s), "read 'Char' type mismatch, get type: %d.", p->getType());
+            snprintf(s, sizeof(s), "read 'Char' type mismatch, get type: %d.", (p.get() ? p->getType() : 0));
             throw TC_Xml_Exception(s);
         }
     }
@@ -57,7 +57,7 @@ public:
         else if (isRequire)
         {
             char s[128];
-            snprintf(s, sizeof(s), "read 'Uint8' type mismatch, get type: %d.", p->getType());
+            snprintf(s, sizeof(s), "read 'Uint8' type mismatch, get type: %d.", (p.get() ? p->getType() : 0));
             throw TC_Xml_Exception(s);
         }
     }
@@ -71,7 +71,7 @@ public:
         else if (isRequire)
         {
             char s[128];
-            snprintf(s, sizeof(s), "read 'Short' type mismatch, get type: %d.", p->getType());
+            snprintf(s, sizeof(s), "read 'Short' type mismatch, get type: %d.", (p.get() ? p->getType() : 0));
             throw TC_Xml_Exception(s);
         }
     }
@@ -85,7 +85,7 @@ public:
         else if (isRequire)
         {
             char s[128];
-            snprintf(s, sizeof(s), "read 'Uint16' type mismatch, get type: %d.", p->getType());
+            snprintf(s, sizeof(s), "read 'Uint16' type mismatch, get type: %d.", (p.get() ? p->getType() : 0));
             throw TC_Xml_Exception(s);
         }
     }
@@ -99,7 +99,7 @@ public:
         else if (isRequire)
         {
             char s[128];
-            snprintf(s, sizeof(s), "read 'Int32' type mismatch, get type: %d.", p->getType());
+            snprintf(s, sizeof(s), "read 'Int32' type mismatch, get type: %d.", (p.get() ? p->getType() : 0));
             throw TC_Xml_Exception(s);
         }
     }
@@ -113,7 +113,7 @@ public:
         else if (isRequire)
         {
             char s[128];
-            snprintf(s, sizeof(s), "read 'UInt32' type mismatch, get type: %d.", p->getType());
+            snprintf(s, sizeof(s), "read 'UInt32' type mismatch, get type: %d.", (p.get() ? p->getType() : 0));
             throw TC_Xml_Exception(s);
         }
     }
@@ -127,7 +127,7 @@ public:
         else if (isRequire)
         {
             char s[128];
-            snprintf(s, sizeof(s), "read 'Int64' type mismatch, get type: %d.", p->getType());
+            snprintf(s, sizeof(s), "read 'Int64' type mismatch, get type: %d.", (p.get() ? p->getType() : 0));
             throw TC_Xml_Exception(s);
         }
     }
@@ -141,7 +141,7 @@ public:
         else if (isRequire)
         {
             char s[128];
-            snprintf(s, sizeof(s), "read 'Float' type mismatch, get type: %d.", p->getType());
+            snprintf(s, sizeof(s), "read 'Float' type mismatch, get type: %d.", (p.get() ? p->getType() : 0));
             throw TC_Xml_Exception(s);
         }
     }
@@ -155,7 +155,7 @@ public:
         else if (isRequire)
         {
             char s[128];
-            snprintf(s, sizeof(s), "read 'Double' type mismatch, get type: %d.", p->getType());
+            snprintf(s, sizeof(s), "read 'Double' type mismatch, get type: %d.", (p.get() ? p->getType() : 0));
             throw TC_Xml_Exception(s);
         }
     }
@@ -169,7 +169,7 @@ public:
         else if (isRequire)
         {
             char s[128];
-            snprintf(s, sizeof(s), "read 'string' type mismatch, get type: %d.", p->getType());
+            snprintf(s, sizeof(s), "read 'string' type mismatch, get type: %d.", (p.get() ? p->getType() : 0));
             throw TC_Xml_Exception(s);
         }
     }
@@ -191,7 +191,7 @@ public:
         else if (isRequire)
         {
             char s[128];
-            snprintf(s, sizeof(s), "read 'char *' type mismatch, get type: %d.", p->getType());
+            snprintf(s, sizeof(s), "read 'char *' type mismatch, get type: %d.", (p.get() ? p->getType() : 0));
             throw TC_Xml_Exception(s);
         }
     }
@@ -216,7 +216,7 @@ public:
         else if (isRequire)
         {
             char s[128];
-            snprintf(s, sizeof(s), "read 'map' type mismatch, get type: %d.", p->getType());
+            snprintf(s, sizeof(s), "read 'map' type mismatch, get type: %d.", (p.get() ? p->getType() : 0));
             throw TC_Xml_Exception(s);
         }
     }
@@ -240,7 +240,7 @@ public:
         else if (isRequire)
         {
             char s[128];
-            snprintf(s, sizeof(s), "read 'map' type mismatch, get type: %d.", p->getType());
+            snprintf(s, sizeof(s), "read 'map' type mismatch, get type: %d.", (p.get() ? p->getType() : 0));
             throw TC_Xml_Exception(s);
         }
     }
@@ -264,7 +264,7 @@ public:
         else if (isRequire)
         {
             char s[128];
-            snprintf(s, sizeof(s), "read 'map' type mismatch, get type: %d.", p->getType());
+            snprintf(s, sizeof(s), "read 'map' type mismatch, get type: %d.", (p.get() ? p->getType() : 0));
             throw TC_Xml_Exception(s);
         }
     }
@@ -287,7 +287,7 @@ public:
         else if (isRequire)
         {
             char s[128];
-            snprintf(s, sizeof(s), "read 'map' type mismatch, get type: %d.", p->getType());
+            snprintf(s, sizeof(s), "read 'map' type mismatch, get type: %d.", (p.get() ? p->getType() : 0));
             throw TC_Xml_Exception(s);
         }
     }
@@ -310,7 +310,7 @@ public:
         else if (isRequire)
         {
             char s[128];
-            snprintf(s, sizeof(s), "read 'map' type mismatch, get type: %d.", p->getType());
+            snprintf(s, sizeof(s), "read 'map' type mismatch, get type: %d.", (p.get() ? p->getType() : 0));
             throw TC_Xml_Exception(s);
         }
     }
@@ -334,7 +334,7 @@ public:
         else if (isRequire)
         {
             char s[128];
-            snprintf(s, sizeof(s), "read 'map' type mismatch, get type: %d.", p->getType());
+            snprintf(s, sizeof(s), "read 'map' type mismatch, get type: %d.", (p.get() ? p->getType() : 0));
             throw TC_Xml_Exception(s);
         }
     }
@@ -358,7 +358,7 @@ public:
         else if (isRequire)
         {
             char s[128];
-            snprintf(s, sizeof(s), "read 'map' type mismatch, get type: %d.", p->getType());
+            snprintf(s, sizeof(s), "read 'map' type mismatch, get type: %d.", (p.get() ? p->getType() : 0));
             throw TC_Xml_Exception(s);
         }
     }
@@ -382,7 +382,7 @@ public:
         else if (isRequire)
         {
             char s[128];
-            snprintf(s, sizeof(s), "read 'map' type mismatch, get type: %d.", p->getType());
+            snprintf(s, sizeof(s), "read 'map' type mismatch, get type: %d.", (p.get() ? p->getType() : 0));
             throw TC_Xml_Exception(s);
         }
     }
@@ -406,7 +406,7 @@ public:
         else if (isRequire)
         {
             char s[128];
-            snprintf(s, sizeof(s), "read 'map' type mismatch, get type: %d.", p->getType());
+            snprintf(s, sizeof(s), "read 'map' type mismatch, get type: %d.", (p.get() ? p->getType() : 0));
             throw TC_Xml_Exception(s);
         }
     }
@@ -430,7 +430,7 @@ public:
         else if (isRequire)
         {
             char s[128];
-            snprintf(s, sizeof(s), "read 'map' type mismatch, get type: %d.", p->getType());
+            snprintf(s, sizeof(s), "read 'map' type mismatch, get type: %d.", (p.get() ? p->getType() : 0));
             throw TC_Xml_Exception(s);
         }
     }
@@ -454,7 +454,7 @@ public:
         else if (isRequire)
         {
             char s[128];
-            snprintf(s, sizeof(s), "read 'map' type mismatch, get type: %d.", p->getType());
+            snprintf(s, sizeof(s), "read 'map' type mismatch, get type: %d.", (p.get() ? p->getType() : 0));
             throw TC_Xml_Exception(s);
         }
     }
@@ -482,7 +482,7 @@ public:
         else if (isRequire)
         {
             char s[128];
-            snprintf(s, sizeof(s), "read 'vector' type mismatch, get type: %d.", p->getType());
+            snprintf(s, sizeof(s), "read 'vector' type mismatch, get type: %d.", (p.get() ? p->getType() : 0));
             throw TC_Xml_Exception(s);
         }
     }
@@ -509,7 +509,7 @@ public:
         else if (isRequire)
         {
             char s[128];
-            snprintf(s, sizeof(s), "read 'T *' type mismatch, get type: %d.", p->getType());
+            snprintf(s, sizeof(s), "read 'T *' type mismatch, get type: %d.", (p.get() ? p->getType() : 0));
             throw TC_Xml_Exception(s);
         }
     }
@@ -534,7 +534,7 @@ public:
         else if (isRequire)
         {
             char s[128];
-            snprintf(s, sizeof(s), "read 'Char' type mismatch, get type: %d.", p->getType());
+            snprintf(s, sizeof(s), "read 'Char' type mismatch, get type: %d.", (p.get() ? p->getType() : 0));
             throw TC_Xml_Exception(s);
         }
     }


### PR DESCRIPTION
当 p.get() 为 NULL ，并且isRequired的时候， snprintf这里空指针coredump

struct S1
{
  0 optional double f1;
  1 require double f2;
};

s1.readFromJsonString("{}");
读f2的时候触发