### PR TITLE
Fix when Transfer-Encoding=chunked, the body is written into the Header. Resulted in the return of double content

### DIFF
--- a/util/src/tc_http.cpp
+++ b/util/src/tc_http.cpp
@@ -1182,7 +1182,7 @@ bool TC_HttpResponse::incrementDecode(TC_NetWorkBuffer &buff)
 
 		_headLength = p - data.first + 4;
 
-		_iTmpContentLength = parseResponseHeaderString(data.first, data.first + data.second);
+		_iTmpContentLength = parseResponseHeaderString(data.first, data.first + _headLength);
 
 		//304的返回码中头里本来就没有Content-Length，也不会有数据体，头收全了就是真正的收全了
 		if ( (204 == _status) || (304 == _status) )


### PR DESCRIPTION
Fix when Transfer-Encoding=chunked, the body is written into the Header. Resulted in the return of double content