### PR TITLE
enable callback to application when accept new clients

### DIFF
--- a/examples/HttpDemo/HttpServer/HttpServer.cpp
+++ b/examples/HttpDemo/HttpServer/HttpServer.cpp
@@ -30,6 +30,7 @@ HttpServer::initialize()
 
     addServant<HttpImp>(ServerConfig::Application + "." + ServerConfig::ServerName + ".HttpObj");
     addServantProtocol(ServerConfig::Application + "." + ServerConfig::ServerName + ".HttpObj",&TC_NetWorkBuffer::parseHttp);
+    addAcceptCallback(std::bind(&HttpServer::onNewClient, this, std::placeholders::_1));
 }
 /////////////////////////////////////////////////////////////////
 void
@@ -38,6 +39,12 @@ HttpServer::destroyApp()
     //destroy application here:
     //...
 }
+
+void HttpServer::onNewClient(TC_EpollServer::Connection* conn)
+{
+    std::cout << "New client from " << conn->getIp() << ":" << conn->getPort() << std::endl;
+}
+
 /////////////////////////////////////////////////////////////////
 int
 main(int argc, char* argv[])

--- a/examples/HttpDemo/HttpServer/HttpServer.h
+++ b/examples/HttpDemo/HttpServer/HttpServer.h
@@ -42,6 +42,9 @@ public:
      *
      **/
     virtual void destroyApp();
+
+private:
+    void onNewClient(TC_EpollServer::Connection*);
 };
 
 extern HttpServer g_app;

--- a/servant/libservant/Application.cpp
+++ b/servant/libservant/Application.cpp
@@ -963,6 +963,19 @@ void Application::addServantProtocol(const string& servant, const TC_NetWorkBuff
     getEpollServer()->getBindAdapter(adapterName)->setProtocol(protocol);
 }
 
+void Application::addAcceptCallback(const TC_EpollServer::accept_callback_functor& cb)
+{
+    _acceptFuncs.push_back(cb);
+}
+
+void Application::onAccept(TC_EpollServer::Connection* cPtr)
+{
+    for (size_t i = 0; i < _acceptFuncs.size(); ++i)
+    {
+        _acceptFuncs[i](cPtr);
+    }
+}
+
 void Application::addServantOnClose(const string& servant, const TC_EpollServer::close_functor& cf)
 {
     string adapterName = ServantHelperManager::getInstance()->getServantAdapter(servant);
@@ -1134,6 +1147,8 @@ void Application::initializeServer()
     }
 
     _epollServer = new TC_EpollServer(ServerConfig::NetThread);
+
+    _epollServer->setOnAccept(std::bind(&Application::onAccept, this, std::placeholders::_1));
 
     //初始化服务是否对空链接进行超时检查
     bool bEnable = (_conf.get("/tars/application/server<emptyconcheck>","0")=="1")?true:false;

--- a/servant/servant/Application.h
+++ b/servant/servant/Application.h
@@ -20,6 +20,7 @@
 #include <iostream>
 #include <set>
 #include <signal.h>
+#include <vector>
 
 #include "util/tc_autoptr.h"
 #include "util/tc_config.h"
@@ -243,6 +244,13 @@ public:
      */
     void addServantProtocol(const string &servant, const TC_NetWorkBuffer::protocol_functor &protocol);
 
+    /**
+     * @desc 添加接收新链接的回调
+     * 
+     * @param cb
+     */
+    void addAcceptCallback(const TC_EpollServer::accept_callback_functor& cb);
+
 protected:
     /**
      * 初始化, 只会进程调用一次
@@ -399,6 +407,13 @@ protected:
 protected:
 
     /**
+     * @desc callback when accept new client
+     * 
+     * @param cPtr
+     */
+    void onAccept(TC_EpollServer::Connection* cPtr);
+
+    /**
      *
      *
      * @param command
@@ -497,6 +512,8 @@ protected:
      * communicator
      */
     static CommunicatorPtr     _communicator;
+
+    std::vector<TC_EpollServer::accept_callback_functor> _acceptFuncs;
 
 #if TARS_SSL
     /**

--- a/util/include/util/tc_epoll_server.h
+++ b/util/include/util/tc_epoll_server.h
@@ -2253,6 +2253,14 @@ public:
      */
     size_t getLogicThreadNum();
 
+    // 接收新的客户端链接时的回调
+    typedef std::function<void (TC_EpollServer::Connection*)> accept_callback_functor;
+
+    /*
+     * 设置接收链接的回调
+     */
+    void setOnAccept(const accept_callback_functor& f) { _acceptFunc = f; }
+
 	//回调给应用服务
     //Callback to application service
 	typedef std::function<void(TC_EpollServer*)> application_callback_functor;
@@ -2369,6 +2377,10 @@ private:
      */
     heartbeat_callback_functor _heartFunc;
 
+    /**
+     * 接收链接的回调函数
+     */
+    accept_callback_functor _acceptFunc;
 };
 
 typedef TC_AutoPtr<TC_EpollServer> TC_EpollServerPtr;

--- a/util/src/tc_epoll_server.cpp
+++ b/util/src/tc_epoll_server.cpp
@@ -1933,6 +1933,7 @@ TC_EpollServer::TC_EpollServer(unsigned int iNetThreadNum)
 , _bTerminate(false)
 , _handleStarted(false)
 , _pLocalLogger(NULL)
+, _acceptFunc(NULL)
 {
 #if TARGET_PLATFORM_WINDOWS
     WSADATA wsadata;
@@ -2273,6 +2274,11 @@ void TC_EpollServer::addConnection(TC_EpollServer::Connection *cPtr, int fd, TC_
     else
     {
         netThread->addUdpConnection(cPtr);
+    }
+    // 回调
+    if (_acceptFunc != NULL)
+    {
+        _acceptFunc(cPtr);
     }
 }
 


### PR DESCRIPTION
feature:
when server accept new incoming client, enable the application to notify this event(through callback). 

testcode/example:
examples/HttpDemo/HttpServer

notice:
In my project, when a new client connected, server need to declare what services it(the server) supplies. 
I'm opening the PR for the purpose of in case anyone else also facing the same scenario as we did.