### PR TITLE
fix: fix consistent hash bug

### DIFF
--- a/util/include/util/tc_consistent_hash_new.h
+++ b/util/include/util/tc_consistent_hash_new.h
@@ -163,6 +163,18 @@ public:
     int getIndex(const string & key, unsigned int & iIndex);
 
     /**
+     * @brief 获取某key对应到的节点node的下标.
+     * @brief Gets the subscript of the node to which a certain key corresponds
+     *
+     * @param key      key
+     * @param iIndex  对应到的节点下标
+     * @param iIndex  the subscript of the node to which corresponds
+     * @return        0:获取成功   -1:没有被添加的节点
+     * @return        0:obtain successfully  -1:no nodes added
+     */
+    int getIndex(int32_t key, unsigned int & iIndex);
+
+    /**
      * @brief 获取某hashcode对应到的节点node的下标.
      * @brief Gets the subscript of the node to which a certain hashcode corresponds
      *
@@ -172,7 +184,7 @@ public:
      * @return        0:获取成功   -1:没有被添加的节点
      * @return        0:obtain successfully  -1:no nodes added
      */
-    int getIndex(int32_t hashcode, unsigned int & iIndex);
+    int getIndexBase(int32_t hashcode, unsigned int & iIndex);
 
     /**
      * @brief 获取当前hash列表的长度.

--- a/util/src/tc_consistent_hash_new.cpp
+++ b/util/src/tc_consistent_hash_new.cpp
@@ -199,11 +199,15 @@ int TC_ConsistentHashNew::getIndex(const string & key, unsigned int & iIndex)
     vector<char> data = TC_MD5::md5bin(key);
     int32_t iCode = _ptrHashAlg->hash(data.data(), data.size());
 
-    return getIndex(iCode, iIndex);
+    return getIndexBase(iCode, iIndex);
 }
 
+int TC_ConsistentHashNew::getIndex(int32_t key, unsigned int & iIndex)
+{
+    return getIndex(std::to_string(key), iIndex);
+}
 
-int TC_ConsistentHashNew::getIndex(int32_t hashcode, unsigned int & iIndex)
+int TC_ConsistentHashNew::getIndexBase(int32_t hashcode, unsigned int & iIndex)
 {
     if(_ptrHashAlg.get() == NULL || _vHashList.size() == 0)
     {
@@ -211,13 +215,10 @@ int TC_ConsistentHashNew::getIndex(int32_t hashcode, unsigned int & iIndex)
         return -1;
     }
 
-    // 只保留32位
-    size_t iCode = (hashcode & 0xFFFFFFFFL);
-
     int low = 0;
     int high = (int)_vHashList.size();
 
-    if(iCode <= (size_t)_vHashList[0].iHashCode || iCode > (size_t)_vHashList[high-1].iHashCode)
+    if(hashcode <= _vHashList[0].iHashCode || hashcode > _vHashList[high-1].iHashCode)
     {
         iIndex = _vHashList[0].iIndex;
         return 0;
@@ -227,7 +228,7 @@ int TC_ConsistentHashNew::getIndex(int32_t hashcode, unsigned int & iIndex)
     while (low < high - 1)
     {
         int mid = (low + high) / 2;
-        if ((size_t)_vHashList[mid].iHashCode > iCode)
+        if (_vHashList[mid].iHashCode > hashcode)
         {
             high = mid;
         }


### PR DESCRIPTION
使用tars_consistent_hash时，如果key是连续的，分布会非常不均匀。原因有两点
1. 没有对tars_consistent_hash传入的key进行hash
2. 获取节点的时候逻辑有bug，导致可能一直获取第一个节点（_vHashList[0].iHashCode是个负数，转成size_t后成了一个很大的数）