### PR TITLE
TC_Shm::init windows缺少_bOwner赋值 及 不应当在全局 using namespace

### DIFF
--- a/util/include/util/tc_ex.h
+++ b/util/include/util/tc_ex.h
@@ -20,10 +20,10 @@
 #include <stdexcept>
 #include <string>
 
-using namespace std;
-
 namespace tars
 {
+using namespace std;
+
 /////////////////////////////////////////////////
 /** 
 * @file  tc_ex.h 

--- a/util/src/tc_shm.cpp
+++ b/util/src/tc_shm.cpp
@@ -40,6 +40,8 @@ void TC_Shm::init(size_t iShmSize, key_t iKey, bool bOwner)
     assert(_pshm == NULL);
 
 #if TARGET_PLATFORM_WINDOWS
+    _bOwner     = bOwner;
+
     // 首先试图打开一个命名的内存映射文件对象  
     HANDLE hMap = ::OpenFileMapping(FILE_MAP_ALL_ACCESS, 0, TC_Common::tostr(iKey).c_str());
     if (NULL == hMap)

--- a/util/src/tc_shm.cpp
+++ b/util/src/tc_shm.cpp
@@ -47,7 +47,7 @@ void TC_Shm::init(size_t iShmSize, key_t iKey, bool bOwner)
     if (NULL == hMap)
     {    
         // 打开失败，创建之
-        hMap = ::CreateFileMapping(INVALID_HANDLE_VALUE, NULL,PAGE_READWRITE,0, iShmSize, TC_Common::tostr(iKey).c_str());
+        hMap = ::CreateFileMapping(INVALID_HANDLE_VALUE, NULL,PAGE_READWRITE,0, (DWORD)iShmSize, TC_Common::tostr(iKey).c_str());
         // 映射对象的一个视图，得到指向共享内存的指针，设置里面的数据
         _pshm = ::MapViewOfFile(hMap, FILE_MAP_ALL_ACCESS, 0, 0, 0);
     }
@@ -97,6 +97,7 @@ int TC_Shm::detach()
     {
         UnmapViewOfFile(_pshm);
         CloseHandle(_shemID);
+        _pshm = NULL;
     }
     return 0;
 #else


### PR DESCRIPTION
1. [TC_Shm::init windows缺少_bOwner赋值 #132](https://github.com/TarsCloud/TarsCpp/issues/132)
2. 降低using namespace的可见性

