### PR TITLE
Change format of files to fix compile errors under windows

### DIFF
--- a/examples/UtilDemo/demo-util/test_tc_http.cpp
+++ b/examples/UtilDemo/demo-util/test_tc_http.cpp
@@ -1,4 +1,4 @@
-//
+﻿//
 // Created by jarod on 2020/2/20.
 //
 

--- a/util/include/util/tc_xml.h
+++ b/util/include/util/tc_xml.h
@@ -1,4 +1,4 @@
-#ifndef __TC_XML_H_
+﻿#ifndef __TC_XML_H_
 #define __TC_XML_H_
 
 #include <string>

--- a/util/src/tc_xml.cpp
+++ b/util/src/tc_xml.cpp
@@ -1,4 +1,4 @@
-/**
+﻿/**
  * Tencent is pleased to support the open source community by making Tars available.
  *
  * Copyright (C) 2016THL A29 Limited, a Tencent company. All rights reserved.


### PR DESCRIPTION
Change format of some files to UTF-8 BOM to fix compile errors under windows without changing any codes in these files.