### PR TITLE
解决服务节点权重更新时哈希表和一致性哈希环不更新的问题

### DIFF
--- a/servant/servant/AdapterProxy.h
+++ b/servant/servant/AdapterProxy.h
@@ -375,6 +375,8 @@ private:
      */
     int                                       _staticWeight;
 
+    bool                                      _staticWeightChanged;
+
     /*
      * 超时请求的回包回来后，是否打印超时的日志信息
      */

--- a/servant/servant/AdapterProxy.h
+++ b/servant/servant/AdapterProxy.h
@@ -167,12 +167,34 @@ public:
     /**
      * 设置节点的静态权重值
      */
-    inline void setWeight(int iWeight) { _staticWeight = iWeight; }
+    inline void setWeight(int iWeight)
+    {
+        if(_staticWeight != iWeight)
+            _staticWeightChanged = true;
+        _staticWeight = iWeight;
+    }
 
     /**
      * 获取节点的静态权重值
      */
     inline int getWeight() { return _staticWeight; }
+
+    /**
+     * 将权重变化标识重置为false
+     */
+    inline void resetWeightChanged() { _staticWeightChanged = false; }
+
+    /**
+     * 判断权重静态权重值是否变化, 参数reset为true时将权重变化标识重置为false
+     */
+     inline bool checkWeightChanged(bool reset = false)
+     {
+         bool changed = _staticWeightChanged;
+         if(reset)
+             _staticWeightChanged = false;
+         return changed;
+     }
+
     /**
      * 获取id
      */


### PR DESCRIPTION
之前的代码中，如果只是服务节点权重发生变化，_lastHashStaticProxys[i]和 _vRegProxys[i]指向的是同一个AdapterProxy,
所以 _lastHashStaticProxys[i]->getWeight() != _vRegProxys[i]->getWeight() 条件一直为false,
从而导致哈希表和一致性哈希环不会更新。