### PR TITLE
set timeout options to prevent "connnect", "real_query" to be blocked for tens of minutes 

### DIFF
--- a/util/include/util/tc_mysql.h
+++ b/util/include/util/tc_mysql.h
@@ -95,6 +95,18 @@ struct TC_DBConf
     int _flag;
 
     /**
+    * 连接超时
+    * Port
+    */
+    int _connectTimeout;
+
+    /**
+    * 读写超时
+    * Port
+    */
+    int _writeReadTimeout;
+
+    /**
     * @brief 构造函数
     * @brief Constructor
     */
@@ -125,17 +137,29 @@ struct TC_DBConf
     {
         map<string, string> mpTmp = mpParam;
 
-        _host        = mpTmp["dbhost"];
-        _user        = mpTmp["dbuser"];
-        _password    = mpTmp["dbpass"];
-        _database    = mpTmp["dbname"];
-        _charset     = mpTmp["charset"];
-        _port        = atoi(mpTmp["dbport"].c_str());
-        _flag        = 0;
+        _host               = mpTmp["dbhost"];
+        _user               = mpTmp["dbuser"];
+        _password           = mpTmp["dbpass"];
+        _database           = mpTmp["dbname"];
+        _charset            = mpTmp["charset"];
+        _port               = atoi(mpTmp["dbport"].c_str());
+        _flag               = 0;        
+        _connectTimeout     = atoi(mpTmp["connectTimeout"].c_str());
+        _writeReadTimeout   = atoi(mpTmp["writeReadTimeout"].c_str());
 
         if(mpTmp["dbport"] == "")
         {
             _port = 3306;
+        }
+
+        if(mpTmp["connectTimeout"] == "")
+        {
+            _connectTimeout = 5;
+        }
+
+        if(mpTmp["writeReadTimeout"] == "")
+        {
+            _writeReadTimeout = 15;
         }
     }
 

--- a/util/src/tc_mysql.cpp
+++ b/util/src/tc_mysql.cpp
@@ -95,6 +95,26 @@ void TC_Mysql::connect()
     }
     
 
+    //设置连接超时
+    if(_dbConf._connectTimeout > 0)  {
+        if (mysql_options(_pstMql, MYSQL_OPT_CONNECT_TIMEOUT, &_dbConf._connectTimeout)) {
+            throw TC_Mysql_Exception(string("TC_Mysql::connect: mysql_options MYSQL_OPT_CONNECT_TIMEOUT ") + TC_Common::tostr(_dbConf._connectTimeout) + ":" + string(mysql_error(_pstMql)));
+        }
+    }
+
+    
+    if(_dbConf._writeReadTimeout > 0)  {
+        //设置读超时
+        if (mysql_options(_pstMql, MYSQL_OPT_READ_TIMEOUT, &_dbConf._writeReadTimeout)) {
+            throw TC_Mysql_Exception(string("TC_Mysql::connect: mysql_options MYSQL_OPT_READ_TIMEOUT ") + TC_Common::tostr(_dbConf._writeReadTimeout) + ":" + string(mysql_error(_pstMql)));
+        }
+        //设置写超时
+        if (mysql_options(_pstMql, MYSQL_OPT_WRITE_TIMEOUT, &_dbConf._writeReadTimeout)) {
+            throw TC_Mysql_Exception(string("TC_Mysql::connect: mysql_options MYSQL_OPT_WRITE_TIMEOUT ") + TC_Common::tostr(_dbConf._writeReadTimeout) + ":" + string(mysql_error(_pstMql)));
+        }
+    }
+
+
     if (mysql_real_connect(_pstMql, _dbConf._host.c_str(), _dbConf._user.c_str(), _dbConf._password.c_str(), _dbConf._database.c_str(), _dbConf._port, NULL, _dbConf._flag) == NULL) 
     {
         throw TC_Mysql_Exception("[TC_Mysql::connect]: mysql_real_connect: " + string(mysql_error(_pstMql)));


### PR DESCRIPTION
Set the MYSQL_OPT_CONNECT_TIMEOUT, MYSQL_OPT_READ_TIMEOUT, MYSQL_OPT_WRITE_TIMEOUT options to prevent switching VIP/restarting the gateway after unplugging the network cable, causing "connnect", "real_query", etc. to be blocked for tens of minutes 