### PR TITLE
Update AppProtocol.h

### DIFF
--- a/servant/servant/AppProtocol.h
+++ b/servant/servant/AppProtocol.h
@@ -622,7 +622,6 @@ public:
 
                 is.read(rsp.iRequestId, 3, false);
                 is.read(rsp.iMessageType, 4, false);
-                is.read(rsp.iRet, 5, false);
 
                 if (rsp.iRet < TARSSERVERUNKNOWNERR)
                 {


### PR DESCRIPTION
fix:删除is.read(rsp.iRet, 5, false)；避免tup协议时，读取异常