### PR TITLE
协程调度机制调整

### DIFF
--- a/servant/libservant/CoroutineScheduler.cpp
+++ b/servant/libservant/CoroutineScheduler.cpp
@@ -39,6 +39,9 @@
 namespace tars 
 {
 
+#define MAX_WAIT_TIME_MS 1000
+#define MIN_WAIT_TIME_MS 1
+
 #if TARGET_PLATFORM_WINDOWS
 
 // x86_64
@@ -54,9 +57,6 @@ namespace tars
 #else
 # define MIN_STACKSIZE  4 * 1024
 #endif
-
-#define MAX_WAIT_TIME_MS 1000
-#define MIN_WAIT_TIME_MS 1
 
 void system_info_( SYSTEM_INFO * si) {
     ::GetSystemInfo( si);
@@ -528,12 +528,14 @@ void CoroutineScheduler::run()
 
         }
 
+        //获取第一个即将timeout的剩余时长
         int waitTime = wakeupbytimeout();
 
         if(CoroutineInfo::CoroutineHeadEmpty(&_active) && (_activeCoroQueue.size() <= 0))
         {
             waitTime = min(max(waitTime, MIN_WAIT_TIME_MS), MAX_WAIT_TIME_MS);
             TC_ThreadLock::Lock lock(_monitor);
+            //限定最多等待时长为waitTime,尽量保证sleep的协程及时被唤醒
             _monitor.timedWait(waitTime);
         }
 

--- a/servant/libservant/CoroutineScheduler.cpp
+++ b/servant/libservant/CoroutineScheduler.cpp
@@ -55,6 +55,9 @@ namespace tars
 # define MIN_STACKSIZE  4 * 1024
 #endif
 
+#define MAX_WAIT_TIME_MS 1000
+#define MIN_WAIT_TIME_MS 1
+
 void system_info_( SYSTEM_INFO * si) {
     ::GetSystemInfo( si);
 }
@@ -512,19 +515,27 @@ void CoroutineScheduler::run()
 {
     while(!_terminal)
     {
-        if(CoroutineInfo::CoroutineHeadEmpty(&_avail) && CoroutineInfo::CoroutineHeadEmpty(&_active))
-        {
-            TC_ThreadLock::Lock lock(_monitor);
+        wakeupbyself();
 
-            if(_activeCoroQueue.size() <= 0)
-            {
-                _monitor.timedWait(1000);
-            }
+        if(!CoroutineInfo::CoroutineHeadEmpty(&_avail))
+        {
+            CoroutineInfo *coro = _avail._next;
+
+            assert(coro != NULL);
+
+            // switchCoro(&_mainCoro, coro);
+            switchCoro(coro);
+
         }
 
-        wakeupbytimeout();
+        int waitTime = wakeupbytimeout();
 
-        wakeupbyself();
+        if(CoroutineInfo::CoroutineHeadEmpty(&_active) && (_activeCoroQueue.size() <= 0))
+        {
+            waitTime = min(max(waitTime, MIN_WAIT_TIME_MS), MAX_WAIT_TIME_MS);
+            TC_ThreadLock::Lock lock(_monitor);
+            _monitor.timedWait(waitTime);
+        }
 
         wakeup();
 
@@ -542,17 +553,6 @@ void CoroutineScheduler::run()
 
                 --iLoop;
             }
-
-        }
-
-        if(!CoroutineInfo::CoroutineHeadEmpty(&_avail))
-        {
-            CoroutineInfo *coro = _avail._next;
-
-            assert(coro != NULL);
-
-            // switchCoro(&_mainCoro, coro);
-            switchCoro(coro);
 
         }
 
@@ -711,8 +711,9 @@ void CoroutineScheduler::wakeup()
     }
 }
 
-void CoroutineScheduler::wakeupbytimeout()
+int CoroutineScheduler::wakeupbytimeout()
 {
+    int leftTime = MAX_WAIT_TIME_MS;
     if(!_terminal)
     {
         if(_timeoutCoroId.size() > 0)
@@ -722,7 +723,11 @@ void CoroutineScheduler::wakeupbytimeout()
             {
                 multimap<int64_t, uint32_t>::iterator it = _timeoutCoroId.begin();
 
-                if(it == _timeoutCoroId.end() || it->first > iNow)
+                if(it == _timeoutCoroId.end())
+                    break;
+
+                leftTime = it->first - iNow;
+                if(leftTime > 0)
                     break;
 
                 CoroutineInfo *coro = _all_coro[it->second];
@@ -736,6 +741,7 @@ void CoroutineScheduler::wakeupbytimeout()
 
         }
     }
+    return leftTime;
 }
 
 void CoroutineScheduler::terminate()

--- a/servant/servant/CoroutineScheduler.h
+++ b/servant/servant/CoroutineScheduler.h
@@ -459,7 +459,7 @@ private:
     /**
      * 唤醒休眠的协程
      */
-    void wakeupbytimeout();
+    int wakeupbytimeout();
 
     /**
      * 放到active的协程链表中


### PR DESCRIPTION
协程调度机制调整，尽量保证sleep的协程及时被唤醒，
解决sleep的协程经常休眠1秒钟，远远超过其设定休眠时长(经常是毫秒级)的问题。