### PR TITLE
fix: fix config parse bug

### DIFF
--- a/util/src/tc_config.cpp
+++ b/util/src/tc_config.cpp
@@ -238,7 +238,9 @@ void TC_ConfigDomain::setParamValue(const string &line)
         }
     }
 
-    setParamValue(line, "");
+    // also need parse
+    string name = parse(TC_Common::trim(line, " \r\n\t"));
+    setParamValue(name, "");
 }
 
 string TC_ConfigDomain::parse(const string& s)


### PR DESCRIPTION
修复这个issue提到的问题：特定情况下TC_Config读取配置的bug
#157 