### PR TITLE
fix TC_ThreadQueue中多个线程同时调用condition_variable.wait()等待时可能出现的惊群效应

### DIFF
--- a/util/include/util/tc_thread_queue.h
+++ b/util/include/util/tc_thread_queue.h
@@ -185,7 +185,7 @@ template<typename T, typename D> bool TC_ThreadQueue<T, D>::pop_front(T& t, size
             }
             else {
                 //超时了
-                if (_cond.wait_for(lock, std::chrono::milliseconds(millsecond)) == std::cv_status::timeout) {
+                if (!_cond.wait_for(lock, std::chrono::milliseconds(millsecond), [this] { return !_queue.empty(); })) {
                     return false;
                 }
             }
@@ -353,7 +353,7 @@ template<typename T, typename D> bool TC_ThreadQueue<T, D>::swap(queue_type &q, 
             }
             else {
                 //超时了
-                if (_cond.wait_for(lock, std::chrono::milliseconds(millsecond)) == std::cv_status::timeout) {
+                if (!_cond.wait_for(lock, std::chrono::milliseconds(millsecond), [this] { return !_queue.empty(); })) {
                     return false;
                 }
             }

--- a/util/include/util/tc_thread_queue.h
+++ b/util/include/util/tc_thread_queue.h
@@ -42,7 +42,7 @@ template<typename T, typename D = deque<T> >
 class TC_ThreadQueue
 {
 public:
-    TC_ThreadQueue():_size(0){};
+    TC_ThreadQueue():_size(0), _bTerminate(false){};
 
 public:
 
@@ -139,6 +139,11 @@ public:
      */
     bool empty() const;
 
+    /**
+     * @brief  调用后, 所有正在进行的、将要进行的阻塞等待将立即返回.
+     */
+    void terminate();
+
 protected:
 	TC_ThreadQueue(const TC_ThreadQueue&) = delete;
 	TC_ThreadQueue(TC_ThreadQueue&&) = delete;
@@ -161,6 +166,9 @@ protected:
 
 	//锁
     mutable std::mutex _mutex;
+    
+    //结束工作否，若为true则所有的阻塞等待都将立即返回
+    bool _bTerminate;
 };
 
 template<typename T, typename D> T TC_ThreadQueue<T, D>::front()
@@ -176,22 +184,17 @@ template<typename T, typename D> bool TC_ThreadQueue<T, D>::pop_front(T& t, size
 
         std::unique_lock<std::mutex> lock(_mutex);
 
-        if (_queue.empty()) {
-            if (millsecond == 0) {
-                return false;
-            }
-            if (millsecond == (size_t) -1) {
-                _cond.wait(lock);
-            }
-            else {
-                //超时了
-                if (!_cond.wait_for(lock, std::chrono::milliseconds(millsecond), [this] { return !_queue.empty(); })) {
-                    return false;
-                }
-            }
+        // 此处等待两个条件： 1.来数据了; 2.terminate.
+        // 任一条件满足都将打破等待立即返回
+        if (millsecond == (size_t) -1) {
+            _cond.wait(lock, [this] { return !_queue.empty() || _bTerminate; });
+        }
+        else if (millsecond > 0) {
+            _cond.wait_for(lock, std::chrono::milliseconds(millsecond), [this] { return !_queue.empty() || _bTerminate; });
         }
 
-        if (_queue.empty()) {
+        // 超时了数据还没到 或 还没超时就被terminate打破了, 直接返回
+        if (_queue.empty() || _bTerminate) {
             return false;
         }
 
@@ -344,22 +347,17 @@ template<typename T, typename D> bool TC_ThreadQueue<T, D>::swap(queue_type &q, 
     if(wait) {
         std::unique_lock<std::mutex> lock(_mutex);
 
-        if (_queue.empty()) {
-            if (millsecond == 0) {
-                return false;
-            }
-            if (millsecond == (size_t) -1) {
-                _cond.wait(lock);
-            }
-            else {
-                //超时了
-                if (!_cond.wait_for(lock, std::chrono::milliseconds(millsecond), [this] { return !_queue.empty(); })) {
-                    return false;
-                }
-            }
+        // 此处等待两个条件： 1.来数据了; 2.terminate.
+        // 任一条件满足都将打破等待立即返回
+        if (millsecond == (size_t) -1) {
+            _cond.wait(lock, [this] { return !_queue.empty() || _bTerminate; });
+        }
+        else if (millsecond > 0) {
+            _cond.wait_for(lock, std::chrono::milliseconds(millsecond), [this] { return !_queue.empty() || _bTerminate; });
         }
 
-        if (_queue.empty()) {
+        // 超时了数据还没到 或 还没超时就被terminate打破了, 直接返回
+        if (_queue.empty() || _bTerminate) {
             return false;
         }
 
@@ -401,6 +399,12 @@ template<typename T, typename D> bool TC_ThreadQueue<T, D>::empty() const
 {
 	std::lock_guard<std::mutex> lock(_mutex);
     return _queue.empty();
+}
+
+template<typename T, typename D> void TC_ThreadQueue<T, D>::terminate() {
+    std::lock_guard<std::mutex> lock(_mutex);
+    _bTerminate = true;
+    _cond.notify_all();
 }
 
 }


### PR DESCRIPTION
TC_ThreadQueue中多个线程同时调用condition_variable.wait()等待时，queue中插入了新数据并且notify后，一个线程正常拿到数据并返回。  但其他线程未拿到数据且未到等待时限 就提前返回的现象。