### PR TITLE
fix TC_ThreadQueue 可能出现的惊群效应 & terminate退出时阻塞等待不用非得等到超时

### DIFF
--- a/util/include/util/tc_thread_queue.h
+++ b/util/include/util/tc_thread_queue.h
@@ -185,7 +185,7 @@ template<typename T, typename D> bool TC_ThreadQueue<T, D>::pop_front(T& t, size
             }
             else {
                 //超时了
-                if (_cond.wait_for(lock, std::chrono::milliseconds(millsecond)) == std::cv_status::timeout) {
+                if (!_cond.wait_for(lock, std::chrono::milliseconds(millsecond), [this] { return !_queue.empty(); })) {
                     return false;
                 }
             }
@@ -353,7 +353,7 @@ template<typename T, typename D> bool TC_ThreadQueue<T, D>::swap(queue_type &q, 
             }
             else {
                 //超时了
-                if (_cond.wait_for(lock, std::chrono::milliseconds(millsecond)) == std::cv_status::timeout) {
+                if (!_cond.wait_for(lock, std::chrono::milliseconds(millsecond), [this] { return !_queue.empty(); })) {
                     return false;
                 }
             }

--- a/util/include/util/tc_thread_queue.h
+++ b/util/include/util/tc_thread_queue.h
@@ -42,7 +42,7 @@ template<typename T, typename D = deque<T> >
 class TC_ThreadQueue
 {
 public:
-    TC_ThreadQueue():_size(0){};
+    TC_ThreadQueue():_size(0), _bTerminate(false){};
 
 public:
 
@@ -139,6 +139,11 @@ public:
      */
     bool empty() const;
 
+    /**
+     * @brief  调用后, 所有正在进行的、将要进行的阻塞等待将立即返回.
+     */
+    void terminate();
+
 protected:
 	TC_ThreadQueue(const TC_ThreadQueue&) = delete;
 	TC_ThreadQueue(TC_ThreadQueue&&) = delete;
@@ -161,6 +166,9 @@ protected:
 
 	//锁
     mutable std::mutex _mutex;
+    
+    //结束工作否，若为true则所有的阻塞等待都将立即返回
+    bool _bTerminate;
 };
 
 template<typename T, typename D> T TC_ThreadQueue<T, D>::front()
@@ -176,22 +184,17 @@ template<typename T, typename D> bool TC_ThreadQueue<T, D>::pop_front(T& t, size
 
         std::unique_lock<std::mutex> lock(_mutex);
 
-        if (_queue.empty()) {
-            if (millsecond == 0) {
-                return false;
-            }
-            if (millsecond == (size_t) -1) {
-                _cond.wait(lock);
-            }
-            else {
-                //超时了
-                if (!_cond.wait_for(lock, std::chrono::milliseconds(millsecond), [this] { return !_queue.empty(); })) {
-                    return false;
-                }
-            }
+        // 此处等待两个条件： 1.来数据了; 2.terminate.
+        // 任一条件满足都将打破等待立即返回
+        if (millsecond == (size_t) -1) {
+            _cond.wait(lock, [this] { return !_queue.empty() || _bTerminate; });
+        }
+        else if (millsecond > 0) {
+            _cond.wait_for(lock, std::chrono::milliseconds(millsecond), [this] { return !_queue.empty() || _bTerminate; });
         }
 
-        if (_queue.empty()) {
+        // 超时了数据还没到 或 还没超时就被terminate打破了, 直接返回
+        if (_queue.empty() || _bTerminate) {
             return false;
         }
 
@@ -344,22 +347,17 @@ template<typename T, typename D> bool TC_ThreadQueue<T, D>::swap(queue_type &q, 
     if(wait) {
         std::unique_lock<std::mutex> lock(_mutex);
 
-        if (_queue.empty()) {
-            if (millsecond == 0) {
-                return false;
-            }
-            if (millsecond == (size_t) -1) {
-                _cond.wait(lock);
-            }
-            else {
-                //超时了
-                if (!_cond.wait_for(lock, std::chrono::milliseconds(millsecond), [this] { return !_queue.empty(); })) {
-                    return false;
-                }
-            }
+        // 此处等待两个条件： 1.来数据了; 2.terminate.
+        // 任一条件满足都将打破等待立即返回
+        if (millsecond == (size_t) -1) {
+            _cond.wait(lock, [this] { return !_queue.empty() || _bTerminate; });
+        }
+        else if (millsecond > 0) {
+            _cond.wait_for(lock, std::chrono::milliseconds(millsecond), [this] { return !_queue.empty() || _bTerminate; });
         }
 
-        if (_queue.empty()) {
+        // 超时了数据还没到 或 还没超时就被terminate打破了, 直接返回
+        if (_queue.empty() || _bTerminate) {
             return false;
         }
 
@@ -401,6 +399,12 @@ template<typename T, typename D> bool TC_ThreadQueue<T, D>::empty() const
 {
 	std::lock_guard<std::mutex> lock(_mutex);
     return _queue.empty();
+}
+
+template<typename T, typename D> void TC_ThreadQueue<T, D>::terminate() {
+    std::lock_guard<std::mutex> lock(_mutex);
+    _bTerminate = true;
+    _cond.notify_all();
 }
 
 }


### PR DESCRIPTION
1. 修复了TC_ThreadQueue可能出现：一个notify，多个wait都被打破，但只有一个线程获得数据，其他线程没获得数据又未超时 但提前返回的现象。
2. TC_ThreadQueue新增terminate()方法。调用后，所有正在进行的、将要进行的阻塞等待都会立即返回，不用非得等到超时才退出。