### PR TITLE
Fix the coredump problem of tars service after turning on the tars_op…

### DIFF
--- a/servant/servant/Message.h
+++ b/servant/servant/Message.h
@@ -240,12 +240,11 @@ struct ReqMessage : public TC_HandleBase
 
     uint32_t					iCoroId;
 
+    map<string, string>         cookie;          // cookie内容
 
-#ifdef TARS_OPENTRACKING
+    #ifdef TARS_OPENTRACKING
     std::unordered_map<std::string, std::string> trackInfoMap; //调用链信息
-#endif
-
-    map<string, string>             cookie;          // cookie内容
+    #endif
 };
 
 typedef TC_AutoPtr<ReqMessage>  ReqMessagePtr;

--- a/servant/servant/ServantProxy.h
+++ b/servant/servant/ServantProxy.h
@@ -153,14 +153,17 @@ public:
      *  objectProxy Pointer
      */
     shared_ptr<ObjectProxy *> _objectProxyOwn;                    //保存ObjectProxy对象的指针数组
-#ifdef TARS_OPENTRACKING
-    std::unordered_map<std::string, std::string> _trackInfoMap;
-#endif
+
 
     /**
      * cookie
      */
     map<string, string>             _cookie;          // cookie内容
+
+
+    #ifdef TARS_OPENTRACKING
+    std::unordered_map<std::string, std::string> _trackInfoMap;
+    #endif
 };
 
 


### PR DESCRIPTION
Fix the coredump problem of tars service after turning on the "tars_opentracking" compilation switch 