### PR TITLE
Hotfix/edisenwang k/fix tc json bug

### DIFF
--- a/servant/tup/TarsJson.h
+++ b/servant/tup/TarsJson.h
@@ -538,37 +538,37 @@ public:
 
     static JsonValueNumPtr writeJson(Char n)
     {
-        return (new JsonValueNum(n,true));
+        return (new JsonValueNum(static_cast<int64_t>(n),true));
     }
 
     static JsonValueNumPtr writeJson(UInt8 n)
     {
-        return (new JsonValueNum(n,true));
+        return (new JsonValueNum(static_cast<int64_t>(n),true));
     }
 
     static JsonValueNumPtr writeJson(Short n)
     {
-        return (new JsonValueNum(n,true));
+        return (new JsonValueNum(static_cast<int64_t>(n),true));
     }
 
     static JsonValueNumPtr writeJson(UInt16 n)
     {
-        return (new JsonValueNum(n,true));
+        return (new JsonValueNum(static_cast<int64_t>(n),true));
     }
 
     static JsonValueNumPtr writeJson(Int32 n)
     {
-        return (new JsonValueNum(n,true));
+        return (new JsonValueNum(static_cast<int64_t>(n),true));
     }
 
     static JsonValueNumPtr writeJson(UInt32 n)
     {
-        return (new JsonValueNum(n,true));
+        return (new JsonValueNum(static_cast<int64_t>(n),true));
     }
 
     static JsonValueNumPtr writeJson(Int64 n)
     {
-        return (new JsonValueNum((double)n,true));
+        return (new JsonValueNum(static_cast<int64_t>(n),true));
     }
 
     static JsonValueNumPtr writeJson(Float n)
@@ -578,7 +578,7 @@ public:
 
     static JsonValueNumPtr writeJson(Double n)
     {
-        return (new JsonValueNum(n));
+        return (new JsonValueNum(static_cast<double>(n)));
     }
 
     static JsonValueStringPtr writeJson(const std::string& s)

--- a/util/include/util/tc_json.h
+++ b/util/include/util/tc_json.h
@@ -47,7 +47,7 @@ enum eJsonType
 	eJsonTypeNum,
 	eJsonTypeObj,
 	eJsonTypeArray,
-	eJsonTypeBoolean
+	eJsonTypeBoolean,
 };
 
 /*
@@ -100,10 +100,14 @@ public:
 	JsonValueNum(double d,bool b=false):value(d),isInt(b)
 	{
 	}
+	JsonValueNum(int64_t v,bool b=true):lvalue(v),isInt(b)
+	{
+	}
 	JsonValueNum()
 	{
 		isInt=false;
 		value=0.0f;
+		lvalue=0;
 	}
 	eJsonType getType()
 	{
@@ -112,6 +116,7 @@ public:
 	virtual ~JsonValueNum(){}
 public:
 	double value;
+	int64_t lvalue;
 	bool isInt;
 };
 typedef TC_AutoPtr<JsonValueNum> JsonValueNumPtr;


### PR DESCRIPTION
解决使用double类型来表示long 类型数据的问题，LONG类型数据用double类型数据表示会丢失精度