### PR TITLE
修复宏FFDLOG(x,y,z)的相关实现中没有根据参数来生成日志文件路径及文件名的问题

### DIFF
--- a/servant/libservant/RemoteLogger.cpp
+++ b/servant/libservant/RemoteLogger.cpp
@@ -679,7 +679,7 @@ void RemoteTimeLogger::initTimeLogger(TimeLogger *pTimeLogger,const string &sApp
 	string sAppSrvName;
     string sFilePath;
     
-    if(_app.empty() && _server.empty())
+    if(sApp.empty() && sServer.empty())
     {
         sAppSrvName = "";
         if(_logpath.empty())
@@ -695,8 +695,8 @@ void RemoteTimeLogger::initTimeLogger(TimeLogger *pTimeLogger,const string &sApp
     }
     else
     {
-        sAppSrvName = _hasAppNamePrefix?(_app + "." + _server):"";
-        sFilePath = _logpath + FILE_SEP + _app + FILE_SEP + _server + FILE_SEP + sAppSrvName;
+        sAppSrvName = _hasAppNamePrefix?(sApp+ "." + sServer):"";
+        sFilePath = _logpath + FILE_SEP + sApp + FILE_SEP + sServer+ FILE_SEP + sAppSrvName;
     }
 
     if(!sFile.empty())


### PR DESCRIPTION
以前的日志模块中宏FFDLOG(x,y,z)的含义应该是可以自定义应用名x和服务名y来生成对应的路径下的日志文件z的，目前不支持了，不确定维护者这么修改是个bug还是故意为之。