### PR TITLE
fix: fix tc_autoptr.h Type p to nullptr

### DIFF
--- a/util/include/util/tc_autoptr.h
+++ b/util/include/util/tc_autoptr.h
@@ -172,7 +172,7 @@ public:
 	 *  
      * @param p
      */
-    TC_AutoPtr(T* p = 0)
+    TC_AutoPtr(T* p = nullptr)
     {
         _ptr = p;
 


### PR DESCRIPTION
Fix tc_autoptr.h Type p to nullptr

Log: