### PR TITLE
clear vector or map when tars struct reset

### DIFF
--- a/tools/tars2cpp/tars2cpp.cpp
+++ b/tools/tars2cpp/tars2cpp.cpp
@@ -832,6 +832,15 @@ string Tars2Cpp::generateH(const StructPtr& pPtr, const string& namespaceId) con
             continue;
         }
 
+        VectorPtr vPtr = VectorPtr::dynamicCast(member[j]->getTypePtr());
+        MapPtr mPtr = MapPtr::dynamicCast(member[j]->getTypePtr());
+        // 如果是vector或者map，reset时需要调用clear方法
+        if (vPtr || mPtr)
+        {
+            s << TAB << member[j]->getId() << ".clear();" << endl;
+            continue;
+        }
+
         if (member[j]->hasDefault())
         {
             BuiltinPtr bPtr  = BuiltinPtr::dynamicCast(member[j]->getTypePtr());


### PR DESCRIPTION
tars目前的resetDefautlt函数，没有针对vector或者map进行clear操作