### PR TITLE
AdapterProxy与服务端自动ping保活

### DIFF
--- a/servant/libservant/AdapterProxy.cpp
+++ b/servant/libservant/AdapterProxy.cpp
@@ -43,7 +43,7 @@ AdapterProxy::AdapterProxy(ObjectProxy * pObjectProxy, const EndpointInfo &ep, C
 , _frequenceFailInvoke(0)
 , _frequenceFailTime(0)
 , _nextRetryTime(0)
-, _nextTarsPingTime(0)
+, _nextKeepAliveTime(0)
 //, _connTimeout(false)
 , _connExc(false)
 , _connExcCnt(0)
@@ -989,7 +989,7 @@ void AdapterProxy::doTimeout()
     }
 }
 
-void AdapterProxy::doTarsPing()
+void AdapterProxy::doKeepAlive()
 {
     if (!checkActive(false))
     {
@@ -997,13 +997,13 @@ void AdapterProxy::doTarsPing()
     }
 
     time_t now = TNOW;
-    if (now < _nextTarsPingTime)
+    if (now < _nextKeepAliveTime)
     {
         return;
     }
 
-    _nextTarsPingTime = now + _communicator->getTarsPingInterval();
-    TLOGTARS("[AdapterProxy::doTarsPing, " << _objectProxy->name() << ", " << _trans->getConnectionString() << "]" << endl);
+    _nextKeepAliveTime = now + _communicator->getKeepAliveInterval();
+    TLOGTARS("[AdapterProxy::doKeepAlive, " << _objectProxy->name() << ", " << _trans->getConnectionString() << "]" << endl);
 
     ReqMessage *msg = new ReqMessage();
 

--- a/servant/libservant/Application.cpp
+++ b/servant/libservant/Application.cpp
@@ -962,7 +962,7 @@ void Application::outClient(ostream &os)
     os << TC_Common::outfill("stat")                        << _communicator->getProperty("stat") << endl;
     os << TC_Common::outfill("property")                    << _communicator->getProperty("property") << endl;
     os << TC_Common::outfill("report-interval")             << _communicator->getProperty("report-interval") << endl;
-    os << TC_Common::outfill("tars-ping-interval")             << _communicator->getProperty("tars-ping-interval") << endl;
+    os << TC_Common::outfill("keep-alive-interval")             << _communicator->getProperty("keep-alive-interval") << endl;
 //    os << TC_Common::outfill("sample-rate")                 << _communicator->getProperty("sample-rate") << endl;
 //    os << TC_Common::outfill("max-sample-count")            << _communicator->getProperty("max-sample-count") << endl;
     os << TC_Common::outfill("netthread")                  << _communicator->getProperty("netthread") << endl;

--- a/servant/libservant/Application.cpp
+++ b/servant/libservant/Application.cpp
@@ -962,6 +962,7 @@ void Application::outClient(ostream &os)
     os << TC_Common::outfill("stat")                        << _communicator->getProperty("stat") << endl;
     os << TC_Common::outfill("property")                    << _communicator->getProperty("property") << endl;
     os << TC_Common::outfill("report-interval")             << _communicator->getProperty("report-interval") << endl;
+    os << TC_Common::outfill("tars-ping-interval")             << _communicator->getProperty("tars-ping-interval") << endl;
 //    os << TC_Common::outfill("sample-rate")                 << _communicator->getProperty("sample-rate") << endl;
 //    os << TC_Common::outfill("max-sample-count")            << _communicator->getProperty("max-sample-count") << endl;
     os << TC_Common::outfill("netthread")                  << _communicator->getProperty("netthread") << endl;

--- a/servant/libservant/Communicator.cpp
+++ b/servant/libservant/Communicator.cpp
@@ -48,6 +48,7 @@ Communicator::Communicator()
 , _statReport(NULL)
 , _timeoutLogFlag(true)
 
+, _tarsPingInterval(0)
 // #ifdef TARS_OPENTRACKING
 // , _traceManager(NULL)
 // #endif
@@ -63,6 +64,7 @@ Communicator::Communicator(TC_Config& conf, const string& domain/* = CONFIG_ROOT
 : _initialized(false)
 , _terminating(false)
 , _timeoutLogFlag(true)
+, _tarsPingInterval(0)
 // #ifdef TARS_OPENTRACKING
 // , _traceManager(NULL)
 // #endif
@@ -392,6 +394,13 @@ void Communicator::initialize()
     _minTimeout = TC_Common::strto<int64_t>(getProperty("min-timeout", "100"));
     if(_minTimeout < 1)
         _minTimeout = 1;
+
+    _tarsPingInterval = TC_Common::strto<int64_t>(getProperty("tars-ping-interval", "0"))/1000;
+    TLOGERROR( "[_tarsPingInterval:" << _tarsPingInterval << endl);
+    if (_tarsPingInterval<5 && _tarsPingInterval!=0)
+    {
+        _tarsPingInterval = 5;
+    }
 
     StatFPrx statPrx = NULL;
     if (!statObj.empty())

--- a/servant/libservant/Communicator.cpp
+++ b/servant/libservant/Communicator.cpp
@@ -48,7 +48,7 @@ Communicator::Communicator()
 , _statReport(NULL)
 , _timeoutLogFlag(true)
 
-, _tarsPingInterval(0)
+, _keepAliveInterval(0)
 // #ifdef TARS_OPENTRACKING
 // , _traceManager(NULL)
 // #endif
@@ -64,7 +64,7 @@ Communicator::Communicator(TC_Config& conf, const string& domain/* = CONFIG_ROOT
 : _initialized(false)
 , _terminating(false)
 , _timeoutLogFlag(true)
-, _tarsPingInterval(0)
+, _keepAliveInterval(0)
 // #ifdef TARS_OPENTRACKING
 // , _traceManager(NULL)
 // #endif
@@ -395,11 +395,10 @@ void Communicator::initialize()
     if(_minTimeout < 1)
         _minTimeout = 1;
 
-    _tarsPingInterval = TC_Common::strto<int64_t>(getProperty("tars-ping-interval", "0"))/1000;
-    TLOGERROR( "[_tarsPingInterval:" << _tarsPingInterval << endl);
-    if (_tarsPingInterval<5 && _tarsPingInterval!=0)
+    _keepAliveInterval = TC_Common::strto<int64_t>(getProperty("keep-alive-interval", "0"))/1000;
+    if (_keepAliveInterval<5 && _keepAliveInterval!=0)
     {
-        _tarsPingInterval = 5;
+        _keepAliveInterval = 5;
     }
 
     StatFPrx statPrx = NULL;

--- a/servant/libservant/CommunicatorEpoll.cpp
+++ b/servant/libservant/CommunicatorEpoll.cpp
@@ -426,6 +426,21 @@ void CommunicatorEpoll::doTimeout()
     }
 }
 
+void CommunicatorEpoll::doTarsPing()
+{
+    assert(_threadId == this_thread::get_id());
+
+    if (_communicator->getTarsPingInterval() == 0)
+    {
+        return;
+    }
+
+    for(size_t i = 0; i < getObjNum(); ++i)
+    {
+        getObjectProxy(i)->doTarsPing();
+    }
+}
+
 void CommunicatorEpoll::doStat()
 {
 	assert(_threadId == this_thread::get_id());
@@ -577,6 +592,10 @@ void CommunicatorEpoll::initializeEpoller()
 
 	_timerIds = { id1, id2, id3 };
 
+    if (_communicator->getTarsPingInterval() > 0) {
+        auto id = _epoller->postRepeated(1000 * 2, false, std::bind(&CommunicatorEpoll::doTarsPing, this));
+        _timerIds.emplace_back(id);
+    }
 }
 
 void CommunicatorEpoll::run()

--- a/servant/libservant/CommunicatorEpoll.cpp
+++ b/servant/libservant/CommunicatorEpoll.cpp
@@ -426,18 +426,18 @@ void CommunicatorEpoll::doTimeout()
     }
 }
 
-void CommunicatorEpoll::doTarsPing()
+void CommunicatorEpoll::doKeepAlive()
 {
     assert(_threadId == this_thread::get_id());
 
-    if (_communicator->getTarsPingInterval() == 0)
+    if (_communicator->getKeepAliveInterval() == 0)
     {
         return;
     }
 
     for(size_t i = 0; i < getObjNum(); ++i)
     {
-        getObjectProxy(i)->doTarsPing();
+        getObjectProxy(i)->doKeepAlive();
     }
 }
 
@@ -592,8 +592,8 @@ void CommunicatorEpoll::initializeEpoller()
 
 	_timerIds = { id1, id2, id3 };
 
-    if (_communicator->getTarsPingInterval() > 0) {
-        auto id = _epoller->postRepeated(1000 * 2, false, std::bind(&CommunicatorEpoll::doTarsPing, this));
+    if (_communicator->getKeepAliveInterval() > 0) {
+        auto id = _epoller->postRepeated(1000 * 2, false, std::bind(&CommunicatorEpoll::doKeepAlive, this));
         _timerIds.emplace_back(id);
     }
 }

--- a/servant/libservant/ObjectProxy.cpp
+++ b/servant/libservant/ObjectProxy.cpp
@@ -374,6 +374,19 @@ void ObjectProxy::doTimeout()
     }
 }
 
+void ObjectProxy::doTarsPing()
+{
+    const vector<AdapterProxy*> & vAdapterProxy = _endpointManger->getAdapters();
+
+    for(size_t iAdapter=0; iAdapter< vAdapterProxy.size();++iAdapter)
+    {
+        if(vAdapterProxy[iAdapter] != NULL)
+        {
+            vAdapterProxy[iAdapter]->doTarsPing();
+        }
+    }
+}
+
 void ObjectProxy::mergeStat(map<StatMicMsgHead, StatMicMsgBody> & mStatMicMsg)
 {
     const vector<AdapterProxy*> & vAdapterProxy = _endpointManger->getAdapters();

--- a/servant/libservant/ObjectProxy.cpp
+++ b/servant/libservant/ObjectProxy.cpp
@@ -374,7 +374,7 @@ void ObjectProxy::doTimeout()
     }
 }
 
-void ObjectProxy::doTarsPing()
+void ObjectProxy::doKeepAlive()
 {
     const vector<AdapterProxy*> & vAdapterProxy = _endpointManger->getAdapters();
 
@@ -382,7 +382,7 @@ void ObjectProxy::doTarsPing()
     {
         if(vAdapterProxy[iAdapter] != NULL)
         {
-            vAdapterProxy[iAdapter]->doTarsPing();
+            vAdapterProxy[iAdapter]->doKeepAlive();
         }
     }
 }

--- a/servant/servant/AdapterProxy.h
+++ b/servant/servant/AdapterProxy.h
@@ -103,6 +103,11 @@ public:
     void doTimeout();
 
     /**
+     * 发送tars_ping
+     */
+    void doTarsPing();
+
+    /**
      * 处理stat
      */
     void mergeStat(map<StatMicMsgHead, StatMicMsgBody> & mStatMicMsg);
@@ -385,6 +390,10 @@ private:
      */
     time_t                                 _nextRetryTime;
 
+    /*
+     * 下一次发起tars_ping请求的时间
+     */
+    time_t                                 _nextTarsPingTime;
 
     /*
      * 是否连接异常

--- a/servant/servant/AdapterProxy.h
+++ b/servant/servant/AdapterProxy.h
@@ -105,7 +105,7 @@ public:
     /**
      * 发送tars_ping
      */
-    void doTarsPing();
+    void doKeepAlive();
 
     /**
      * 处理stat
@@ -393,7 +393,7 @@ private:
     /*
      * 下一次发起tars_ping请求的时间
      */
-    time_t                                 _nextTarsPingTime;
+    time_t                                 _nextKeepAliveTime;
 
     /*
      * 是否连接异常

--- a/servant/servant/Communicator.h
+++ b/servant/servant/Communicator.h
@@ -328,7 +328,7 @@ public:
     /*
      * tars_ping间隔，0：不启用
      */
-    int64_t getTarsPingInterval() { return _tarsPingInterval; }
+    int64_t getKeepAliveInterval() { return _keepAliveInterval; }
 
     /**
      * get resource info
@@ -503,7 +503,7 @@ protected:
     /*
      * tars_ping间隔，0：不启用
      */
-    int64_t                _tarsPingInterval;
+    int64_t                _keepAliveInterval;
 
 	/**
 	 * ssl ctx

--- a/servant/servant/Communicator.h
+++ b/servant/servant/Communicator.h
@@ -325,6 +325,11 @@ public:
      */
     int64_t getMinTimeout() { return _minTimeout; }
 
+    /*
+     * tars_ping间隔，0：不启用
+     */
+    int64_t getTarsPingInterval() { return _tarsPingInterval; }
+
     /**
      * get resource info
      * @return
@@ -494,6 +499,11 @@ protected:
      * 最小的超时时间
      */
     int64_t                _minTimeout;
+
+    /*
+     * tars_ping间隔，0：不启用
+     */
+    int64_t                _tarsPingInterval;
 
 	/**
 	 * ssl ctx

--- a/servant/servant/CommunicatorEpoll.h
+++ b/servant/servant/CommunicatorEpoll.h
@@ -295,7 +295,7 @@ protected:
      * 处理tars_ping
      * @param pi
      */
-    void doTarsPing();
+    void doKeepAlive();
 
     /**
      * 处理stat

--- a/servant/servant/CommunicatorEpoll.h
+++ b/servant/servant/CommunicatorEpoll.h
@@ -292,6 +292,12 @@ protected:
     void doTimeout();
 
     /**
+     * 处理tars_ping
+     * @param pi
+     */
+    void doTarsPing();
+
+    /**
      * 处理stat
      * @param pi
      */

--- a/servant/servant/ObjectProxy.h
+++ b/servant/servant/ObjectProxy.h
@@ -101,6 +101,11 @@ public:
     void doTimeout();
 
     /**
+     * 发起tars_ping请求
+     */
+    void doTarsPing();
+
+    /**
      * 获取CommunicatorEpoll*
      */
     inline CommunicatorEpoll *getCommunicatorEpoll() { return _communicatorEpoll; }

--- a/servant/servant/ObjectProxy.h
+++ b/servant/servant/ObjectProxy.h
@@ -103,7 +103,7 @@ public:
     /**
      * 发起tars_ping请求
      */
-    void doTarsPing();
+    void doKeepAlive();
 
     /**
      * 获取CommunicatorEpoll*


### PR DESCRIPTION
有很大概率碰到rpc客户端刚把请求投递出去的时候服务端因为连接空闲把连接关闭了导致这次请求异常。给AdapterProxy添加自动tars_ping操作来进行连接保活避免这种情况。可以通过模板配置是否开启自动ping以及ping的间隔