### PR TITLE
增加servant按业务请求设置hash选择工作线程

### DIFF
--- a/servant/libservant/AdapterProxy.cpp
+++ b/servant/libservant/AdapterProxy.cpp
@@ -145,7 +145,7 @@ void AdapterProxy::onCloseCallback(TC_Transceiver* trans, TC_Transceiver::CloseR
     if(second > 0) 
     {
         _objectProxy->getCommunicatorEpoll()->reConnect(TNOWMS + second * 1000, trans);
-        TLOGERROR("[trans close:" << _objectProxy->name() << "," << trans->getConnectEndpoint().toString() << ", reconnect:" << second << "]" << endl);
+        TLOGWARN("[trans close:" << _objectProxy->name() << "," << trans->getConnectEndpoint().toString() << ", reconnect:" << second << "]" << endl);
     }   
 }
 

--- a/servant/libservant/AppProtocol.cpp
+++ b/servant/libservant/AppProtocol.cpp
@@ -21,6 +21,7 @@
 // #include "servant/TC_Transceiver.h"
 #include "servant/AdapterProxy.h"
 #include "servant/RemoteLogger.h"
+#include "servant/Message.h"
 #include "tup/Tars.h"
 #include <iostream>
 
@@ -58,7 +59,24 @@ shared_ptr<TC_NetWorkBuffer::Buffer> ProxyProtocol::tarsRequest(RequestPacket& r
 
 	assert(os.getLength() >= 4);
 
-	iHeaderLen = htonl((int)(os.getLength()));
+    iHeaderLen = htonl((int)(os.getLength()));
+
+    if (IS_MSG_TYPE(request.iMessageType, TARSMESSAGETYPEHASH))
+    {
+        auto it = request.status.find(ServantProxy::STATUS_BUSI_HASH_CODE);
+        if (it != request.status.end())
+        {
+            tars::Int64 code = atoll(it->second.c_str());
+            if (code > 0)
+            {
+                code = tars::tars_htonll(code);
+                os.writeBuf("HASH", 4);
+                os.writeBuf((const char *)&code, sizeof(code));
+            }
+        }
+    }
+
+    iHeaderLen = htonl((int)(os.getLength()));
 
 	memcpy((void*)os.getBuffer(), (const char *)&iHeaderLen, sizeof(iHeaderLen));
 

--- a/servant/servant/Message.h
+++ b/servant/servant/Message.h
@@ -109,6 +109,13 @@ struct ThreadPrivateData
     int64_t        _hashCode    = -1;                        //hash值
 
     /**
+     * servant业务线程hash属性，客户端每次调用都进行设置
+     * 如果服务端支持多线程列队模式，则可以设置该值，避免同一客户端的请求都在一个线程处理，充分利用服务端性能
+     */
+    bool           _busiHash    = false;                //是否业务线程取模hash
+    int64_t        _busiHashCode= -1;                   //hash值
+
+    /**
      * 染色信息
      */
     bool           _dyeing      = false;                          //标识当前线程是否需要染色

--- a/servant/servant/ServantProxy.h
+++ b/servant/servant/ServantProxy.h
@@ -760,6 +760,8 @@ public:
 
     static string STATUS_TRACE_KEY; //trace信息
 
+    static string STATUS_BUSI_HASH_CODE;  // 按线程hash值
+
 ///////////////////////////////////////////////////////////////////
 /**
  * socket选项
@@ -997,6 +999,11 @@ public:
      * 获取超时检查参数
      */
     CheckTimeoutInfo tars_get_check_timeout();
+
+    /**
+     * 线程hash, 保证同一key的消息由服务端固定的线程处理
+     */
+    virtual ServantProxy* tars_set_busi_hashcode(int64_t key);
 
     /**
      * hash方法，为保证一段时间内同一个key的消息发送

--- a/util/include/util/tc_epoll_server.h
+++ b/util/include/util/tc_epoll_server.h
@@ -35,6 +35,7 @@
 #include "util/tc_cas_queue.h"
 #include "util/tc_coroutine.h"
 #include "util/tc_openssl.h"
+#include "tup/TarsType.h"
 
 using namespace std;
 
@@ -396,9 +397,9 @@ public:
 
     protected:
 
-        inline int index(uint32_t handleIndex) { return handleIndex % _threadDataQueue.size(); }
+        inline int index(tars::Int64 handleIndex) { return handleIndex % _threadDataQueue.size(); }
 
-        const shared_ptr<DataQueue> &getDataQueue(uint32_t handleIndex);
+        const shared_ptr<DataQueue> &getDataQueue(tars::Int64 handleIndex);
 
     protected:
 


### PR DESCRIPTION
需求：
业务层可以按特定场景指定一系列的请求顺序处理。

虽然服务端可以通过enableQueueMode启用队列模式，但是是按照fd进行hash，存在有以下问题：
1、当客户端只有一个服务时会导致服务端线程负载不均衡
2、运维需要关心技术细节来判断客户端需要运行的实例数量

代码修改考虑以下几个点：
1、客户端不需要关心服务端有多少个线程，服务端也不需要关心有多少个客户端
2、tc_epoll_server只负责网络包处理，不需要去解包
3、前向兼容，所以将hash值接在包的最好（这个方式不是很好）

目前我们应用场景需要这个功能，我先提个pr看下这个功能是否需要，还有就是有没有更优的方式将业务hash值传给服务端进行hash选择工作线程。