### PR TITLE
Fix TC_NetWorkBuffer bug, Optimize doProtocolAnalysis()

### DIFF
--- a/util/src/tc_network_buffer.cpp
+++ b/util/src/tc_network_buffer.cpp
@@ -405,20 +405,21 @@ string TC_NetWorkBuffer::getBuffersString() const
 {
 	string buffer;
 	buffer.resize(_length);
-
-	getBuffers(&buffer[0], _length);
-
+	if (_length > 0)
+	{
+		getBuffers(&buffer[0], _length);
+	}
 	return buffer;
 }
 
 vector<char> TC_NetWorkBuffer::getBuffers() const
 {
 	vector<char> buffer;
-
 	buffer.resize(_length);
-
-	getBuffers(&buffer[0], _length);
-
+	if (_length > 0)
+	{
+		getBuffers(&buffer[0], _length);
+	}
 	return buffer;
 }
 

--- a/util/src/tc_transceiver.cpp
+++ b/util/src/tc_transceiver.cpp
@@ -814,9 +814,9 @@ int TC_Transceiver::doProtocolAnalysis(TC_NetWorkBuffer* buff)
 	{
 		do
 		{
-			ioriginal = buff->getBuffers().size();
+			ioriginal = buff->getBufferLength();
 			ret = _onParserCallback(*buff, this);
-			isurplus = buff->getBuffers().size();
+			isurplus = buff->getBufferLength();
 
 			if (ret == TC_NetWorkBuffer::PACKET_FULL || ret == TC_NetWorkBuffer::PACKET_FULL_CLOSE)
 			{


### PR DESCRIPTION
当_length为0时，buffer[0]数组下标越界，在不报错的情况下进入下级函数会触发assert(length <= getBufferLength())断言。
debug模式下可复现报错，诱因是TC_Transceiver::doProtocolAnalysis函数中在调用完_onParserCallback之后，buff中的协议包已经完全处理，buff为空，此时调用isurplus = buff->getBuffers().size()产生越界处理。
同时出于效率考虑，将buff->getBuffers().size()调用改成buff->getBufferLength()，减少临时对象产生和内存的拷贝。