### PR TITLE
修复TC_Shm类，先detach后无法del的问题

### DIFF
--- a/util/include/util/tc_shm.h
+++ b/util/include/util/tc_shm.h
@@ -68,7 +68,7 @@ public:
 	*  
 	* @param bOwner  是否拥有共享内存,默认为false 
     */
-    TC_Shm(bool bOwner = false) : _bOwner(bOwner),_shmSize(0),_shmKey(0),_bCreate(true), _pshm(NULL) {}
+    TC_Shm(bool bOwner = false) : _bOwner(bOwner),_shmSize(0),_shmKey(0),_bCreate(true), _pshm(NULL), _shemID(0) {}
 
     /**
 	* @brief 构造函数. 

--- a/util/src/tc_shm.cpp
+++ b/util/src/tc_shm.cpp
@@ -120,11 +120,11 @@ int TC_Shm::del()
     return 0;
 #else
     int iRetCode = 0;
-    if (_pshm != NULL)
+    if (_shemID > 0)
     {
         iRetCode = shmctl(_shemID, IPC_RMID, 0);
 
-        _pshm = NULL;
+		_shemID = 0;
     }
 
     return iRetCode;


### PR DESCRIPTION
1 在使用TC_Shm 类函数del 删除创建的共享内存时，发现删除不干净：
![1f28605272537d8d0a971bdd67a3a29](https://user-images.githubusercontent.com/46178930/179943924-3c86bb5a-6fff-45ef-b72c-88d3bd9a8ac4.jpg)

2 经研究，需要先detach再del 才可以干净删除共享内存，但是tc_shm中无法支持：
![8fb7931c242e34e35d4c1f3fed4c39b](https://user-images.githubusercontent.com/46178930/179943525-0146bcb7-b3f6-4d10-80ff-2c5aabf389a3.jpg)
