### PR TITLE
Update Thirdparty.cmake

### DIFF
--- a/cmake/Thirdparty.cmake
+++ b/cmake/Thirdparty.cmake
@@ -122,7 +122,7 @@ if (WIN32)
     endif()
 
     ExternalProject_Add(ADD_${LIB_GTEST}
-            URL http://cdn.tarsyun.com/src/release-1.10.0.zip
+            URL https://github.com/google/googletest/archive/refs/tags/release-1.11.0.tar.gz
             DOWNLOAD_DIR ${CMAKE_SOURCE_DIR}/download
             PREFIX ${CMAKE_BINARY_DIR}
             INSTALL_DIR ${CMAKE_SOURCE_DIR}
@@ -131,13 +131,13 @@ if (WIN32)
             BUILD_IN_SOURCE 1
             BUILD_COMMAND ${CMAKE_COMMAND} --build . --config ${CMAKE_BUILD_TYPE}
             INSTALL_COMMAND ${CMAKE_COMMAND} --build . --config  ${CMAKE_BUILD_TYPE}  --target install
-            URL_MD5 82358affdd7ab94854c8ee73a180fc53
+            URL_MD5 e8a8df240b6938bb6384155d4c37d937
             )
 else()
     set(LIB_GTEST "gtest")
 
     ExternalProject_Add(ADD_${LIB_GTEST}
-            URL http://cdn.tarsyun.com/src/release-1.10.0.fixed.tar.gz
+            URL https://github.com/google/googletest/archive/refs/tags/release-1.11.0.tar.gz
             DOWNLOAD_DIR ${CMAKE_SOURCE_DIR}/download
             PREFIX ${CMAKE_BINARY_DIR}
             INSTALL_DIR ${CMAKE_SOURCE_DIR}
@@ -145,7 +145,7 @@ else()
             SOURCE_DIR ${CMAKE_BINARY_DIR}/src/gtest-lib
             BUILD_IN_SOURCE 1
             BUILD_COMMAND make
-            URL_MD5 6f26d634fa9cac718263c2df20df21a4
+            URL_MD5 e8a8df240b6938bb6384155d4c37d937
             )
 endif()
 


### PR DESCRIPTION
原gtest 1.10版本编译不过，切换到1.11版本。from issue https://github.com/TarsCloud/TarsCpp/issues/239