### PR TITLE
[MSVC][std:c++latest] Fix compiler error

### DIFF
--- a/util/src/tc_strptime.cpp
+++ b/util/src/tc_strptime.cpp
@@ -110,7 +110,7 @@ static const unsigned short int __mon_yday[2][13] =
 
 
 /* Status of lookup: do we use the locale data or the raw data?  */
-enum locale_status { not, loc, raw };
+enum locale_status { null, loc, raw };
 
 # define __isleap(year) \
    ((year) % 4 == 0 && ((year) % 100 != 0 || (year) % 400 == 0))


### PR DESCRIPTION
When building TarsCpp with /std:c++latest on MSVC, we got the following errors, now fix it. See https://godbolt.org/z/6chsKhYEc.

`         F:\gitP\TarsCloud\TarsCpp\util\src\tc_strptime.cpp(113,22): error C2059: syntax error: '!' [F:\gitP\TarsCloud\TarsCpp\build_amd64\util\src\tarsutil.vcxproj]
         F:\gitP\TarsCloud\TarsCpp\util\src\tc_strptime.cpp(113,36): error C2143: syntax error: missing ';' before '}' [F:\gitP\TarsCloud\TarsCpp\build_amd64\util\src\tarsutil.vcxproj]
         F:\gitP\TarsCloud\TarsCpp\util\src\tc_strptime.cpp(113,36): error C2059: syntax error: '}' [F:\gitP\TarsCloud\TarsCpp\build_amd64\util\src\tarsutil.vcxproj]
         F:\gitP\TarsCloud\TarsCpp\util\src\tc_strptime.cpp(201,33): error C2065: 'loc': undeclared identifier [F:\gitP\TarsCloud\TarsCpp\build_amd64\util\src\tarsutil.vcxproj]
         F:\gitP\TarsCloud\TarsCpp\util\src\tc_strptime.cpp(205,32): error C2065: 'raw': undeclared identifier [F:\gitP\TarsCloud\TarsCpp\build_amd64\util\src\tarsutil.vcxproj]
         F:\gitP\TarsCloud\TarsCpp\util\src\tc_strptime.cpp(224,32): error C2065: 'raw': undeclared identifier [F:\gitP\TarsCloud\TarsCpp\build_amd64\util\src\tarsutil.vcxproj]
         F:\gitP\TarsCloud\TarsCpp\util\src\tc_strptime.cpp(522,15): error C2065: 'raw': undeclared identifier [F:\gitP\TarsCloud\TarsCpp\build_amd64\util\src\tarsutil.vcxproj]`