### PR TITLE
fix: 多层嵌套tars文件，当第二次移除同一元素时会崩溃 orderFileNames.erase(it->second);

### DIFF
--- a/tools/tarsmerge/main.cpp
+++ b/tools/tarsmerge/main.cpp
@@ -107,7 +107,7 @@ string doTarsMerge(TC_Option& option, const vector<string>& vTars)
 
 					auto currIt = fileNames.find(currFileName);
 					if(currIt != fileNames.end()) {
-						orderFileNames.insert(currIt->second, fileName);
+						fileNames[fileName] = orderFileNames.insert(currIt->second, fileName);
 					}
 				}
 			}


### PR DESCRIPTION
tarsmerge多层嵌套tars文件，当第二次移除同一元素时会崩溃 orderFileNames.erase(it->second); 