### PR TITLE
Update ObjectProxy.cpp

### DIFF
--- a/servant/libservant/ObjectProxy.cpp
+++ b/servant/libservant/ObjectProxy.cpp
@@ -345,6 +345,11 @@ void ObjectProxy::doKeepAlive()
 	{
 		return;
 	}
+
+    if (_endpointManger->getDirectProxy())
+    {
+        return;
+    }
 	assert(this->getCommunicatorEpoll()->getThreadId() == this_thread::get_id());
 
 	const vector<AdapterProxy*> & vAdapterProxy = _endpointManger->getActiveAdapters(true);


### PR DESCRIPTION
直连的ObjProxy不进行keepAlive