### PR TITLE
ObjectProxy invoke exception callback

### DIFF
--- a/servant/libservant/ObjectProxy.cpp
+++ b/servant/libservant/ObjectProxy.cpp
@@ -282,18 +282,8 @@ void ObjectProxy::doInvokeException(ReqMessage * msg)
 			}
 			else
 			{
-                //先确保adapter 非null
-                if (msg->adapter)
-                {
-                    //异步回调，放入回调处理线程中
-                    _communicatorEpoll->pushAsyncThreadQueue(msg);
-                }
-                else
-                {
-                    TLOGERROR("[ObjectProxy::doInvokeException push adapter is null|" << __LINE__ << endl);
-                    delete msg;
-                    msg = NULL;
-                }
+                _communicatorEpoll->pushAsyncThreadQueue(msg);
+                TLOGERROR("[ObjectProxy::doInvokeException push adapter is null|" << __LINE__ << endl);
 			}
 		}
 		else


### PR DESCRIPTION
obj没有可用的结点时，不会触发callback，业务层无法感知异常