### PR TITLE
修改xxx_fcontext名称

### DIFF
--- a/util/include/util/tc_fcontext.h
+++ b/util/include/util/tc_fcontext.h
@@ -12,8 +12,8 @@ struct transfer_t {
     void    *   data;
 };
 
-extern "C" transfer_t jump_fcontext( fcontext_t const to, void * vp);
-extern "C" fcontext_t make_fcontext( void * sp, std::size_t size, void (* fn)( transfer_t) );
+extern "C" transfer_t tars_jump_fcontext( fcontext_t const to, void * vp);
+extern "C" fcontext_t tars_make_fcontext( void * sp, std::size_t size, void (* fn)( transfer_t) );
 
 }
 

--- a/util/src/asm/jump_arm64_aapcs_elf_gas.S
+++ b/util/src/asm/jump_arm64_aapcs_elf_gas.S
@@ -54,9 +54,9 @@
 .file "jump_arm64_aapcs_elf_gas.S"
 .text
 .align  2
-.global jump_fcontext
-.type   jump_fcontext, %function
-jump_fcontext:
+.global tars_jump_fcontext
+.type   tars_jump_fcontext, %function
+tars_jump_fcontext:
     # prepare stack for GP + FPU
     sub  sp, sp, #0xb0
 
@@ -109,6 +109,6 @@ jump_fcontext:
     add  sp, sp, #0xb0
 
     ret x4
-.size   jump_fcontext,.-jump_fcontext
+.size   tars_jump_fcontext,.-tars_jump_fcontext
 # Mark that we don't need executable stack.
 .section .note.GNU-stack,"",%progbits

--- a/util/src/asm/jump_arm64_aapcs_macho_gas.S
+++ b/util/src/asm/jump_arm64_aapcs_macho_gas.S
@@ -52,9 +52,9 @@
  *******************************************************/
 
 .text
-.globl _jump_fcontext
+.globl _tars_jump_fcontext
 .balign 16
-_jump_fcontext:
+_tars_jump_fcontext:
     ; prepare stack for GP + FPU
     sub  sp, sp, #0xb0
 

--- a/util/src/asm/jump_arm_aapcs_elf_gas.S
+++ b/util/src/asm/jump_arm_aapcs_elf_gas.S
@@ -40,11 +40,11 @@
 
 .file "jump_arm_aapcs_elf_gas.S"
 .text
-.globl jump_fcontext
+.globl tars_jump_fcontext
 .align 2
-.type jump_fcontext,%function
+.type tars_jump_fcontext,%function
 .syntax unified
-jump_fcontext:
+tars_jump_fcontext:
     @ save LR as PC
     push {lr}
     @ save hidden,V1-V8,LR
@@ -82,7 +82,7 @@ jump_fcontext:
 
     @ restore PC
     pop {pc}
-.size jump_fcontext,.-jump_fcontext
+.size tars_jump_fcontext,.-tars_jump_fcontext
 
 @ Mark that we don't need executable stack.
 .section .note.GNU-stack,"",%progbits

--- a/util/src/asm/jump_arm_aapcs_macho_gas.S
+++ b/util/src/asm/jump_arm_aapcs_macho_gas.S
@@ -39,9 +39,9 @@
  *******************************************************/
 
 .text
-.globl _jump_fcontext
+.globl _tars_jump_fcontext
 .align 2
-_jump_fcontext:
+_tars_jump_fcontext:
     @ save LR as PC
     push {lr}
     @ save hidden,V1-V8,LR

--- a/util/src/asm/jump_arm_aapcs_pe_armasm.asm
+++ b/util/src/asm/jump_arm_aapcs_pe_armasm.asm
@@ -26,9 +26,9 @@
 
     AREA |.text|, CODE
     ALIGN 4
-    EXPORT jump_fcontext
+    EXPORT tars_jump_fcontext
 
-jump_fcontext PROC
+tars_jump_fcontext PROC
     ; save LR as PC
     push {lr}
     ; save hidden,V1-V8,LR

--- a/util/src/asm/jump_i386_ms_pe_gas.asm
+++ b/util/src/asm/jump_i386_ms_pe_gas.asm
@@ -32,9 +32,9 @@
 .def	@feat.00;	.scl	3;	.type	0;	.endef
 .set    @feat.00,   1
 
-.globl	_jump_fcontext
-.def	_jump_fcontext;	.scl	2;	.type	32;	.endef
-_jump_fcontext:
+.globl	_tars_jump_fcontext
+.def	_tars_jump_fcontext;	.scl	2;	.type	32;	.endef
+_tars_jump_fcontext:
     /* prepare stack */
     leal  -0x2c(%esp), %esp
 
@@ -71,7 +71,7 @@ _jump_fcontext:
     /* store ESP (pointing to context-data) in EAX */
     movl  %esp, %eax
 
-    /* firstarg of jump_fcontext() == fcontext to jump to */
+    /* firstarg of tars_jump_fcontext() == fcontext to jump to */
     movl  0x30(%esp), %ecx
     
     /* restore ESP (pointing to context-data) from ECX */
@@ -120,4 +120,4 @@ _jump_fcontext:
     jmp *%ecx
 
 .section .drectve
-.ascii " -export:\"jump_fcontext\""
+.ascii " -export:\"tars_jump_fcontext\""

--- a/util/src/asm/jump_i386_ms_pe_masm.asm
+++ b/util/src/asm/jump_i386_ms_pe_masm.asm
@@ -24,7 +24,7 @@
 .model flat, c
 .code
 
-jump_fcontext PROC EXPORT
+tars_jump_fcontext PROC EXPORT
     ; prepare stack
     lea  esp, [esp-02ch]
 
@@ -63,7 +63,7 @@ ENDIF
     ; store ESP (pointing to context-data) in EAX
     mov  eax, esp
 
-    ; firstarg of jump_fcontext() == fcontext to jump to
+    ; firstarg of tars_jump_fcontext() == fcontext to jump to
     mov  ecx, [esp+030h]
     
     ; restore ESP (pointing to context-data) from ECX
@@ -112,5 +112,5 @@ ENDIF
 
     ; jump to context
     jmp ecx
-jump_fcontext ENDP
+tars_jump_fcontext ENDP
 END

--- a/util/src/asm/jump_i386_sysv_elf_gas.S
+++ b/util/src/asm/jump_i386_sysv_elf_gas.S
@@ -26,10 +26,10 @@
 
 .file "jump_i386_sysv_elf_gas.S"
 .text
-.globl jump_fcontext
+.globl tars_jump_fcontext
 .align 2
-.type jump_fcontext,@function
-jump_fcontext:
+.type tars_jump_fcontext,@function
+tars_jump_fcontext:
     leal  -0x18(%esp), %esp  /* prepare stack */
 
 #if !defined(BOOST_USE_TSX)
@@ -45,10 +45,10 @@ jump_fcontext:
     /* store ESP (pointing to context-data) in ECX */
     movl  %esp, %ecx
 
-    /* first arg of jump_fcontext() == fcontext to jump to */
+    /* first arg of tars_jump_fcontext() == fcontext to jump to */
     movl  0x20(%esp), %eax
 
-    /* second arg of jump_fcontext() == data to be transferred */
+    /* second arg of tars_jump_fcontext() == data to be transferred */
     movl  0x24(%esp), %edx
 
     /* restore ESP (pointing to context-data) from EAX */
@@ -77,7 +77,7 @@ jump_fcontext:
 
     /* jump to context */
     jmp *%ecx
-.size jump_fcontext,.-jump_fcontext
+.size tars_jump_fcontext,.-tars_jump_fcontext
 
 /* Mark that we don't need executable stack.  */
 .section .note.GNU-stack,"",%progbits

--- a/util/src/asm/jump_i386_sysv_macho_gas.S
+++ b/util/src/asm/jump_i386_sysv_macho_gas.S
@@ -25,9 +25,9 @@
  ****************************************************************************************/
 
 .text
-.globl _jump_fcontext
+.globl _tars_jump_fcontext
 .align 2
-_jump_fcontext:
+_tars_jump_fcontext:
     leal  -0x18(%esp), %esp  /* prepare stack */
 
 #if !defined(BOOST_USE_TSX)
@@ -43,10 +43,10 @@ _jump_fcontext:
     /* store ESP (pointing to context-data) in ECX */
     movl  %esp, %ecx
 
-    /* first arg of jump_fcontext() == fcontext to jump to */
+    /* first arg of tars_jump_fcontext() == fcontext to jump to */
     movl  0x1c(%esp), %eax
 
-    /* second arg of jump_fcontext() == data to be transferred */
+    /* second arg of tars_jump_fcontext() == data to be transferred */
     movl  0x20(%esp), %edx
 
     /* restore ESP (pointing to context-data) from EAX */

--- a/util/src/asm/jump_mips32_o32_elf_gas.S
+++ b/util/src/asm/jump_mips32_o32_elf_gas.S
@@ -40,11 +40,11 @@
 
 .file "jump_mips32_o32_elf_gas.S"
 .text
-.globl jump_fcontext
+.globl tars_jump_fcontext
 .align 2
-.type jump_fcontext,@function
-.ent jump_fcontext
-jump_fcontext:
+.type tars_jump_fcontext,@function
+.ent tars_jump_fcontext
+tars_jump_fcontext:
     # reserve space on stack
     addiu $sp, $sp, -96
 
@@ -112,8 +112,8 @@ jump_fcontext:
 
     # jump to context
     jr  $t9
-.end jump_fcontext
-.size jump_fcontext, .-jump_fcontext
+.end tars_jump_fcontext
+.size tars_jump_fcontext, .-tars_jump_fcontext
 
 /* Mark that we don't need executable stack.  */
 .section .note.GNU-stack,"",%progbits

--- a/util/src/asm/jump_ppc32_sysv_elf_gas.S
+++ b/util/src/asm/jump_ppc32_sysv_elf_gas.S
@@ -52,12 +52,12 @@
 
 .file "jump_ppc32_sysv_elf_gas.S"
 .text
-.globl jump_fcontext
+.globl tars_jump_fcontext
 .align 2
-.type jump_fcontext,@function
-jump_fcontext:
-    # Linux: jump_fcontext( hidden transfer_t * R3, R4, R5)
-    # Other: transfer_t R3:R4 = jump_fcontext( R3, R4)
+.type tars_jump_fcontext,@function
+tars_jump_fcontext:
+    # Linux: tars_jump_fcontext( hidden transfer_t * R3, R4, R5)
+    # Other: transfer_t R3:R4 = tars_jump_fcontext( R3, R4)
 
     mflr  %r0  # return address from LR
     mffs  %f0  # FPSCR
@@ -195,7 +195,7 @@ jump_fcontext:
 
     # jump to context
     bctr
-.size jump_fcontext, .-jump_fcontext
+.size tars_jump_fcontext, .-tars_jump_fcontext
 
 /* Mark that we don't need executable stack.  */
 .section .note.GNU-stack,"",%progbits

--- a/util/src/asm/jump_ppc32_sysv_macho_gas.S
+++ b/util/src/asm/jump_ppc32_sysv_macho_gas.S
@@ -74,9 +74,9 @@
  *******************************************************/
 
 .text
-.globl _jump_fcontext
+.globl _tars_jump_fcontext
 .align 2
-_jump_fcontext:
+_tars_jump_fcontext:
     ; reserve space on stack
     subi  r1, r1, 244
 

--- a/util/src/asm/jump_ppc32_sysv_xcoff_gas.S
+++ b/util/src/asm/jump_ppc32_sysv_xcoff_gas.S
@@ -72,13 +72,13 @@
  *  -------------------------------------------------  *
  *                                                     *
  *******************************************************/
-.globl .jump_fcontext
-.globl  jump_fcontext[DS]
+.globl .tars_jump_fcontext
+.globl  tars_jump_fcontext[DS]
 .align 2 
-.csect	jump_fcontext[DS]
-jump_fcontext:
-  .long	.jump_fcontext
-.jump_fcontext:
+.csect	tars_jump_fcontext[DS]
+tars_jump_fcontext:
+  .long	.tars_jump_fcontext
+.tars_jump_fcontext:
     # reserve space on stack
     subi  r1, r1, 244
 

--- a/util/src/asm/jump_ppc64_sysv_elf_gas.S
+++ b/util/src/asm/jump_ppc64_sysv_elf_gas.S
@@ -67,33 +67,33 @@
  *******************************************************/
 
 .file "jump_ppc64_sysv_elf_gas.S"
-.globl jump_fcontext
+.globl tars_jump_fcontext
 #if _CALL_ELF == 2
 	.text
 	.align 2
-jump_fcontext:
-        addis   %r2, %r12, .TOC.-jump_fcontext@ha
-        addi    %r2, %r2, .TOC.-jump_fcontext@l
-        .localentry jump_fcontext, . - jump_fcontext
+tars_jump_fcontext:
+        addis   %r2, %r12, .TOC.-tars_jump_fcontext@ha
+        addi    %r2, %r2, .TOC.-tars_jump_fcontext@l
+        .localentry tars_jump_fcontext, . - tars_jump_fcontext
 #else
 	.section ".opd","aw"
 	.align 3
-jump_fcontext:
+tars_jump_fcontext:
 # ifdef _CALL_LINUX
-        .quad   .L.jump_fcontext,.TOC.@tocbase,0
-        .type   jump_fcontext,@function
+        .quad   .L.tars_jump_fcontext,.TOC.@tocbase,0
+        .type   tars_jump_fcontext,@function
         .text
         .align 2
-.L.jump_fcontext:
+.L.tars_jump_fcontext:
 # else
-        .hidden .jump_fcontext
-        .globl  .jump_fcontext
-        .quad   .jump_fcontext,.TOC.@tocbase,0
-        .size   jump_fcontext,24
-        .type   .jump_fcontext,@function
+        .hidden .tars_jump_fcontext
+        .globl  .tars_jump_fcontext
+        .quad   .tars_jump_fcontext,.TOC.@tocbase,0
+        .size   tars_jump_fcontext,24
+        .type   .tars_jump_fcontext,@function
         .text
         .align 2
-.jump_fcontext:
+.tars_jump_fcontext:
 # endif
 #endif
     # reserve space on stack
@@ -189,7 +189,7 @@ jump_fcontext:
 
     # jump to context
     bctr
-	.size jump_fcontext, .-jump_fcontext
+	.size tars_jump_fcontext, .-tars_jump_fcontext
 #else
     # zero in r3 indicates first jump to context-function
     cmpdi %r3, 0
@@ -210,9 +210,9 @@ use_entry_arg:
     # jump to context
     bctr
 # ifdef _CALL_LINUX
-	.size .jump_fcontext, .-.L.jump_fcontext
+	.size .tars_jump_fcontext, .-.L.tars_jump_fcontext
 # else
-	.size .jump_fcontext, .-.jump_fcontext
+	.size .tars_jump_fcontext, .-.tars_jump_fcontext
 # endif
 #endif
 

--- a/util/src/asm/jump_ppc64_sysv_macho_gas.S
+++ b/util/src/asm/jump_ppc64_sysv_macho_gas.S
@@ -68,9 +68,9 @@
 
 .text
 .align 2
-.globl _jump_fcontext
+.globl _tars_jump_fcontext
 
-_jump_fcontext:
+_tars_jump_fcontext:
     ; reserve space on stack
     subi  r1, r1, 184
 

--- a/util/src/asm/jump_ppc64_sysv_xcoff_gas.S
+++ b/util/src/asm/jump_ppc64_sysv_xcoff_gas.S
@@ -7,8 +7,8 @@
 */
 
 .align 2
-.globl .jump_fcontext
-.jump_fcontext:
+.globl .tars_jump_fcontext
+.tars_jump_fcontext:
     # reserve space on stack
     subi  1, 1, 184
 

--- a/util/src/asm/jump_x86_64_ms_pe_gas.asm
+++ b/util/src/asm/jump_x86_64_ms_pe_gas.asm
@@ -89,10 +89,10 @@
 .file	"jump_x86_64_ms_pe_gas.asm"
 .text
 .p2align 4,,15
-.globl	jump_fcontext
-.def	jump_fcontext;	.scl	2;	.type	32;	.endef
-.seh_proc	jump_fcontext
-jump_fcontext:
+.globl	tars_jump_fcontext
+.def	tars_jump_fcontext;	.scl	2;	.type	32;	.endef
+.seh_proc	tars_jump_fcontext
+tars_jump_fcontext:
 .seh_endprologue
 
     leaq  -0x118(%rsp), %rsp /* prepare stack */
@@ -206,4 +206,4 @@ jump_fcontext:
 .seh_endproc
 
 .section .drectve
-.ascii " -export:\"jump_fcontext\""
+.ascii " -export:\"tars_jump_fcontext\""

--- a/util/src/asm/jump_x86_64_ms_pe_masm.asm
+++ b/util/src/asm/jump_x86_64_ms_pe_masm.asm
@@ -84,7 +84,7 @@
 
 .code
 
-jump_fcontext PROC EXPORT FRAME
+tars_jump_fcontext PROC EXPORT FRAME
     .endprolog
 
     ; prepare stack
@@ -201,5 +201,5 @@ ENDIF
 
     ; indirect jump to context
     jmp  r10
-jump_fcontext ENDP
+tars_jump_fcontext ENDP
 END

--- a/util/src/asm/jump_x86_64_sysv_elf_gas.S
+++ b/util/src/asm/jump_x86_64_sysv_elf_gas.S
@@ -26,10 +26,10 @@
 
 .file "jump_x86_64_sysv_elf_gas.S"
 .text
-.globl jump_fcontext
-.type jump_fcontext,@function
+.globl tars_jump_fcontext
+.type tars_jump_fcontext,@function
 .align 16
-jump_fcontext:
+tars_jump_fcontext:
     leaq  -0x38(%rsp), %rsp /* prepare stack */
 
 #if !defined(BOOST_USE_TSX)
@@ -85,7 +85,7 @@ jump_fcontext:
 
     /* indirect jump to context */
     jmp  *%r8
-.size jump_fcontext,.-jump_fcontext
+.size tars_jump_fcontext,.-tars_jump_fcontext
 
 /* Mark that we don't need executable stack.  */
 .section .note.GNU-stack,"",%progbits

--- a/util/src/asm/jump_x86_64_sysv_macho_gas.S
+++ b/util/src/asm/jump_x86_64_sysv_macho_gas.S
@@ -25,9 +25,9 @@
  ****************************************************************************************/
 
 .text
-.globl _jump_fcontext
+.globl _tars_jump_fcontext
 .align 8
-_jump_fcontext:
+_tars_jump_fcontext:
     leaq  -0x38(%rsp), %rsp /* prepare stack */
 
 #if !defined(BOOST_USE_TSX)

--- a/util/src/asm/make_arm64_aapcs_elf_gas.S
+++ b/util/src/asm/make_arm64_aapcs_elf_gas.S
@@ -54,16 +54,16 @@
 .file "make_arm64_aapcs_elf_gas.S"
 .text
 .align  2
-.global make_fcontext
-.type   make_fcontext, %function
-make_fcontext:
+.global tars_make_fcontext
+.type   tars_make_fcontext, %function
+tars_make_fcontext:
     # shift address in x0 (allocated stack) to lower 16 byte boundary
     and x0, x0, ~0xF
 
     # reserve space for context-data on context-stack
     sub  x0, x0, #0xb0
 
-    # third arg of make_fcontext() == address of context-function
+    # third arg of tars_make_fcontext() == address of context-function
     # store address as a PC to jump in
     str  x2, [x0, #0xa0]
 
@@ -80,6 +80,6 @@ finish:
     # exit application
     bl  _exit
 
-.size   make_fcontext,.-make_fcontext
+.size   tars_make_fcontext,.-tars_make_fcontext
 # Mark that we don't need executable stack.
 .section .note.GNU-stack,"",%progbits

--- a/util/src/asm/make_arm64_aapcs_macho_gas.S
+++ b/util/src/asm/make_arm64_aapcs_macho_gas.S
@@ -52,17 +52,17 @@
  *******************************************************/
 
 .text
-.globl _make_fcontext
+.globl _tars_make_fcontext
 .balign 16
 
-_make_fcontext:
+_tars_make_fcontext:
     ; shift address in x0 (allocated stack) to lower 16 byte boundary
     and x0, x0, ~0xF
 
     ; reserve space for context-data on context-stack
     sub  x0, x0, #0xb0
 
-    ; third arg of make_fcontext() == address of context-function
+    ; third arg of tars_make_fcontext() == address of context-function
     ; store address as a PC to jump in
     str  x2, [x0, #0xa0]
 

--- a/util/src/asm/make_arm_aapcs_elf_gas.S
+++ b/util/src/asm/make_arm_aapcs_elf_gas.S
@@ -40,18 +40,18 @@
 
 .file "make_arm_aapcs_elf_gas.S"
 .text
-.globl make_fcontext
+.globl tars_make_fcontext
 .align 2
-.type make_fcontext,%function
+.type tars_make_fcontext,%function
 .syntax unified
-make_fcontext:
+tars_make_fcontext:
     @ shift address in A1 to lower 16 byte boundary
     bic  a1, a1, #15
 
     @ reserve space for context-data on context-stack
     sub  a1, a1, #124
 
-    @ third arg of make_fcontext() == address of context-function
+    @ third arg of tars_make_fcontext() == address of context-function
     str  a3, [a1, #104]
 
     @ compute address of returned transfer_t
@@ -75,7 +75,7 @@ finish:
     mov  a1, #0
     @ exit application
     bl  _exit@PLT
-.size make_fcontext,.-make_fcontext
+.size tars_make_fcontext,.-tars_make_fcontext
 
 @ Mark that we don't need executable stack.
 .section .note.GNU-stack,"",%progbits

--- a/util/src/asm/make_arm_aapcs_macho_gas.S
+++ b/util/src/asm/make_arm_aapcs_macho_gas.S
@@ -39,16 +39,16 @@
  *******************************************************/
 
 .text
-.globl _make_fcontext
+.globl _tars_make_fcontext
 .align 2
-_make_fcontext:
+_tars_make_fcontext:
     @ shift address in A1 to lower 16 byte boundary
     bic  a1, a1, #15
 
     @ reserve space for context-data on context-stack
     sub  a1, a1, #124
 
-    @ third arg of make_fcontext() == address of context-function
+    @ third arg of tars_make_fcontext() == address of context-function
     str  a3, [a1, #108]
 
     @ compute address of returned transfer_t

--- a/util/src/asm/make_arm_aapcs_pe_armasm.asm
+++ b/util/src/asm/make_arm_aapcs_pe_armasm.asm
@@ -27,11 +27,11 @@
 
     AREA |.text|, CODE
     ALIGN 4
-    EXPORT make_fcontext
+    EXPORT tars_make_fcontext
     IMPORT _exit
 
-make_fcontext PROC
-    ; first arg of make_fcontext() == top of context-stack
+tars_make_fcontext PROC
+    ; first arg of tars_make_fcontext() == top of context-stack
     ; save top of context-stack (base) A4
     mov  a4, a1
 
@@ -43,7 +43,7 @@ make_fcontext PROC
 
     ; save top address of context_stack as 'base'
     str  a4, [a1, #0x8]
-    ; second arg of make_fcontext() == size of context-stack
+    ; second arg of tars_make_fcontext() == size of context-stack
     ; compute bottom address of context-stack (limit)
     sub  a4, a4, a2
     ; save bottom address of context-stack as 'limit'
@@ -51,7 +51,7 @@ make_fcontext PROC
     ; save bottom address of context-stack as 'dealloction stack'
     str  a4, [a1, #0x0]
 
-    ; third arg of make_fcontext() == address of context-function
+    ; third arg of tars_make_fcontext() == address of context-function
     str  a3, [a1, #0x34]
 
     ; compute address of returned transfer_t

--- a/util/src/asm/make_i386_ms_pe_gas.asm
+++ b/util/src/asm/make_i386_ms_pe_gas.asm
@@ -32,10 +32,10 @@
 .def	@feat.00;	.scl	3;	.type	0;	.endef
 .set    @feat.00,   1
 
-.globl	_make_fcontext
-.def	_make_fcontext;	.scl	2;	.type	32;	.endef
-_make_fcontext:
-    /* first arg of make_fcontext() == top of context-stack */
+.globl	_tars_make_fcontext
+.def	_tars_make_fcontext;	.scl	2;	.type	32;	.endef
+_tars_make_fcontext:
+    /* first arg of tars_make_fcontext() == top of context-stack */
     movl  0x04(%esp), %eax
 
     /* reserve space for first argument of context-function */
@@ -56,11 +56,11 @@ _make_fcontext:
     /* save x87 control-word */
     fnstcw  0x4(%eax)
 
-    /* first arg of make_fcontext() == top of context-stack */
+    /* first arg of tars_make_fcontext() == top of context-stack */
     movl  0x4(%esp), %ecx
     /* save top address of context stack as 'base' */
     movl  %ecx, 0x14(%eax)
-    /* second arg of make_fcontext() == size of context-stack */
+    /* second arg of tars_make_fcontext() == size of context-stack */
     movl  0x8(%esp), %edx
     /* negate stack size for LEA instruction (== substraction) */
     negl  %edx
@@ -74,7 +74,7 @@ _make_fcontext:
 	xorl  %ecx, %ecx
     movl  %ecx, 0x8(%eax)
 
-    /* third arg of make_fcontext() == address of context-function */
+    /* third arg of tars_make_fcontext() == address of context-function */
     /* stored in EBX */
     movl  0xc(%esp), %ecx
     movl  %ecx, 0x24(%eax)
@@ -82,7 +82,7 @@ _make_fcontext:
     /* compute abs address of label trampoline */
     movl  $trampoline, %ecx
     /* save address of trampoline as return-address for context-function */
-    /* will be entered after calling jump_fcontext() first time */
+    /* will be entered after calling tars_jump_fcontext() first time */
     movl  %ecx, 0x2c(%eax)
 
     /* compute abs address of label finish */
@@ -150,4 +150,4 @@ finish:
 .def	__exit;	.scl	2;	.type	32;	.endef  /* standard C library function */
 
 .section .drectve
-.ascii " -export:\"make_fcontext\""
+.ascii " -export:\"tars_make_fcontext\""

--- a/util/src/asm/make_i386_ms_pe_masm.asm
+++ b/util/src/asm/make_i386_ms_pe_masm.asm
@@ -26,8 +26,8 @@
 _exit PROTO, value:SDWORD
 .code
 
-make_fcontext PROC EXPORT
-    ; first arg of make_fcontext() == top of context-stack
+tars_make_fcontext PROC EXPORT
+    ; first arg of tars_make_fcontext() == top of context-stack
     mov  eax, [esp+04h]
 
     ; reserve space for first argument of context-function
@@ -47,11 +47,11 @@ make_fcontext PROC EXPORT
     ; save x87 control-word
     fnstcw  [eax+04h]
 
-    ; first arg of make_fcontext() == top of context-stack
+    ; first arg of tars_make_fcontext() == top of context-stack
     mov  ecx, [esp+04h]
     ; save top address of context stack as 'base'
     mov  [eax+014h], ecx
-    ; second arg of make_fcontext() == size of context-stack
+    ; second arg of tars_make_fcontext() == size of context-stack
     mov  edx, [esp+08h]
     ; negate stack size for LEA instruction (== substraction)
     neg  edx
@@ -65,7 +65,7 @@ make_fcontext PROC EXPORT
 	xor  ecx, ecx
     mov  [eax+08h], ecx
 
-    ; third arg of make_fcontext() == address of context-function
+    ; third arg of tars_make_fcontext() == address of context-function
     ; stored in EBX
     mov  ecx, [esp+0ch]
     mov  [eax+024h], ecx
@@ -73,7 +73,7 @@ make_fcontext PROC EXPORT
     ; compute abs address of label trampoline
     mov  ecx, trampoline
     ; save address of trampoline as return-address for context-function
-    ; will be entered after calling jump_fcontext() first time
+    ; will be entered after calling tars_jump_fcontext() first time
     mov  [eax+02ch], ecx
 
     ; compute abs address of label finish
@@ -136,5 +136,5 @@ finish:
     ; exit application
     call  _exit
     hlt
-make_fcontext ENDP
+tars_make_fcontext ENDP
 END

--- a/util/src/asm/make_i386_sysv_elf_gas.S
+++ b/util/src/asm/make_i386_sysv_elf_gas.S
@@ -26,11 +26,11 @@
 
 .file "make_i386_sysv_elf_gas.S"
 .text
-.globl make_fcontext
+.globl tars_make_fcontext
 .align 2
-.type make_fcontext,@function
-make_fcontext:
-    /* first arg of make_fcontext() == top of context-stack */
+.type tars_make_fcontext,@function
+tars_make_fcontext:
+    /* first arg of tars_make_fcontext() == top of context-stack */
     movl  0x4(%esp), %eax
 
     /* reserve space for first argument of context-function
@@ -43,7 +43,7 @@ make_fcontext:
     /* reserve space for context-data on context-stack */
     leal  -0x28(%eax), %eax
 
-    /* third arg of make_fcontext() == address of context-function */
+    /* third arg of tars_make_fcontext() == address of context-function */
     /* stored in EBX */
     movl  0xc(%esp), %ecx
     movl  %ecx, 0x10(%eax)
@@ -65,7 +65,7 @@ make_fcontext:
     /* compute abs address of label trampoline */
     addl  $trampoline-1b, %ecx
     /* save address of trampoline as return address */
-    /* will be entered after calling jump_fcontext() first time */
+    /* will be entered after calling tars_jump_fcontext() first time */
     movl  %ecx, 0x18(%eax)
 
     /* compute abs address of label finish */
@@ -101,7 +101,7 @@ finish:
     /* exit application */
     call  _exit@PLT
     hlt
-.size make_fcontext,.-make_fcontext
+.size tars_make_fcontext,.-tars_make_fcontext
 
 /* Mark that we don't need executable stack.  */
 .section .note.GNU-stack,"",%progbits

--- a/util/src/asm/make_i386_sysv_macho_gas.S
+++ b/util/src/asm/make_i386_sysv_macho_gas.S
@@ -25,10 +25,10 @@
  ****************************************************************************************/
 
 .text
-.globl _make_fcontext
+.globl _tars_make_fcontext
 .align 2
-_make_fcontext:
-    /* first arg of make_fcontext() == top of context-stack */
+_tars_make_fcontext:
+    /* first arg of tars_make_fcontext() == top of context-stack */
     movl  0x4(%esp), %eax
 
     /* reserve space for first argument of context-function
@@ -41,7 +41,7 @@ _make_fcontext:
     /* reserve space for context-data on context-stack */
     leal  -0x2c(%eax), %eax
 
-    /* third arg of make_fcontext() == address of context-function */
+    /* third arg of tars_make_fcontext() == address of context-function */
     /* stored in EBX */
     movl  0xc(%esp), %ecx
     movl  %ecx, 0x10(%eax)
@@ -58,7 +58,7 @@ _make_fcontext:
     /* compute abs address of label trampoline */
     addl  $trampoline-1b, %ecx
     /* save address of trampoline as return address */
-    /* will be entered after calling jump_fcontext() first time */
+    /* will be entered after calling tars_jump_fcontext() first time */
     movl  %ecx, 0x18(%eax)
 
     /* compute abs address of label finish */

--- a/util/src/asm/make_mips32_o32_elf_gas.S
+++ b/util/src/asm/make_mips32_o32_elf_gas.S
@@ -40,11 +40,11 @@
 
 .file "make_mips32_o32_elf_gas.S"
 .text
-.globl make_fcontext
+.globl tars_make_fcontext
 .align 2
-.type make_fcontext,@function
-.ent make_fcontext
-make_fcontext:
+.type tars_make_fcontext,@function
+.ent tars_make_fcontext
+tars_make_fcontext:
 #ifdef __PIC__
 .set    noreorder
 .cpload $t9
@@ -63,7 +63,7 @@ make_fcontext:
     #  - 4 bytes for alignment
     addiu $v0, $v0, -128
 
-    # third arg of make_fcontext() == address of context-function
+    # third arg of tars_make_fcontext() == address of context-function
     sw  $a2, 92($v0)
     # save global pointer in context-data
     sw  $gp, 112($v0)
@@ -90,8 +90,8 @@ finish:
     la $t9, _exit
     move $a0, $zero
     jr $t9
-.end make_fcontext
-.size make_fcontext, .-make_fcontext
+.end tars_make_fcontext
+.size tars_make_fcontext, .-tars_make_fcontext
 
 /* Mark that we don't need executable stack.  */
 .section .note.GNU-stack,"",%progbits

--- a/util/src/asm/make_ppc32_sysv_elf_gas.S
+++ b/util/src/asm/make_ppc32_sysv_elf_gas.S
@@ -52,14 +52,14 @@
 
 .file "make_ppc32_sysv_elf_gas.S"
 .text
-.globl make_fcontext
+.globl tars_make_fcontext
 .align 2
-.type make_fcontext,@function
-make_fcontext:
+.type tars_make_fcontext,@function
+tars_make_fcontext:
     # save return address into R6
     mflr  %r6
 
-    # first arg of make_fcontext() == top address of context-function
+    # first arg of tars_make_fcontext() == top address of context-function
     # shift address in R3 to lower 16 byte boundary
     clrrwi  %r3, %r3, 4
 
@@ -67,7 +67,7 @@ make_fcontext:
     # and parameter area + 240 bytes of context-data (R1 % 16 == 0)
     subi  %r3, %r3, 16 + 240
 
-    # third arg of make_fcontext() == address of context-function
+    # third arg of tars_make_fcontext() == address of context-function
 #ifdef __linux__
     # save context-function as PC
     stw  %r5, 16(%r3)
@@ -111,7 +111,7 @@ make_fcontext:
 
 #ifndef __linux__
 trampoline:
-    # On systems other than Linux, jump_fcontext is returning the
+    # On systems other than Linux, tars_jump_fcontext is returning the
     # transfer_t in R3:R4, but we need to pass transfer_t * R3 to
     # our context-function.
     lwz   %r0, 8(%r1)   # address of context-function
@@ -136,7 +136,7 @@ finish:
     # call _exit(0) with special addend 0x8000 for large model
     li  %r3, 0
     bl  _exit + 0x8000@plt
-.size make_fcontext, .-make_fcontext
+.size tars_make_fcontext, .-tars_make_fcontext
 
 /* Provide the GOT pointer for secure PLT, large model. */
 .section .got2,"aw"

--- a/util/src/asm/make_ppc32_sysv_macho_gas.S
+++ b/util/src/asm/make_ppc32_sysv_macho_gas.S
@@ -74,13 +74,13 @@
  *******************************************************/
 
 .text
-.globl _make_fcontext
+.globl _tars_make_fcontext
 .align 2
-_make_fcontext:
+_tars_make_fcontext:
     # save return address into R6
     mflr  r6
 
-    # first arg of make_fcontext() == top address of context-function
+    # first arg of tars_make_fcontext() == top address of context-function
     # shift address in R3 to lower 16 byte boundary
     clrrwi  r3, r3, 4
 
@@ -88,7 +88,7 @@ _make_fcontext:
     # including 64 byte of linkage + parameter area (R1  16 == 0)
     subi  r3, r3, 336
 
-    # third arg of make_fcontext() == address of context-function
+    # third arg of tars_make_fcontext() == address of context-function
     stw  r5, 240(r3)
 
     # set back-chain to zero

--- a/util/src/asm/make_ppc32_sysv_xcoff_gas.S
+++ b/util/src/asm/make_ppc32_sysv_xcoff_gas.S
@@ -72,18 +72,18 @@
  *  -------------------------------------------------  *
  *                                                     *
  *******************************************************/
-	.globl	make_fcontext[DS]
-	.globl .make_fcontext[PR]
+	.globl	tars_make_fcontext[DS]
+	.globl .tars_make_fcontext[PR]
 	.align 2 
-	.csect  make_fcontext[DS]
-make_fcontext:
-	.long .make_fcontext[PR]
-	.csect .make_fcontext[PR], 3
-#.make_fcontext:
+	.csect  tars_make_fcontext[DS]
+tars_make_fcontext:
+	.long .tars_make_fcontext[PR]
+	.csect .tars_make_fcontext[PR], 3
+#.tars_make_fcontext:
     # save return address into R6
     mflr  6
 
-    # first arg of make_fcontext() == top address of context-function
+    # first arg of tars_make_fcontext() == top address of context-function
     # shift address in R3 to lower 16 byte boundary
     clrrwi  3, 3, 4
 
@@ -91,7 +91,7 @@ make_fcontext:
     # including 64 byte of linkage + parameter area (R1 % 16 == 0)
     subi  3, 3, 336
 
-    # third arg of make_fcontext() == address of context-function
+    # third arg of tars_make_fcontext() == address of context-function
     stw  5, 240(3)
 
     # set back-chain to zero

--- a/util/src/asm/make_ppc64_sysv_elf_gas.S
+++ b/util/src/asm/make_ppc64_sysv_elf_gas.S
@@ -67,39 +67,39 @@
  *******************************************************/
 
 .file "make_ppc64_sysv_elf_gas.S"
-.globl make_fcontext
+.globl tars_make_fcontext
 #if _CALL_ELF == 2
 	.text
 	.align 2
-make_fcontext:
-	addis	%r2, %r12, .TOC.-make_fcontext@ha
-	addi	%r2, %r2, .TOC.-make_fcontext@l
-	.localentry make_fcontext, . - make_fcontext
+tars_make_fcontext:
+	addis	%r2, %r12, .TOC.-tars_make_fcontext@ha
+	addi	%r2, %r2, .TOC.-tars_make_fcontext@l
+	.localentry tars_make_fcontext, . - tars_make_fcontext
 #else
 	.section ".opd","aw"
 	.align 3
-make_fcontext:
+tars_make_fcontext:
 # ifdef _CALL_LINUX
-	.quad	.L.make_fcontext,.TOC.@tocbase,0
-	.type	make_fcontext,@function
+	.quad	.L.tars_make_fcontext,.TOC.@tocbase,0
+	.type	tars_make_fcontext,@function
 	.text
 	.align 2
-.L.make_fcontext:
+.L.tars_make_fcontext:
 # else
-	.hidden	.make_fcontext
-	.globl	.make_fcontext
-	.quad	.make_fcontext,.TOC.@tocbase,0
-	.size	make_fcontext,24
-	.type	.make_fcontext,@function
+	.hidden	.tars_make_fcontext
+	.globl	.tars_make_fcontext
+	.quad	.tars_make_fcontext,.TOC.@tocbase,0
+	.size	tars_make_fcontext,24
+	.type	.tars_make_fcontext,@function
 	.text
 	.align 2
-.make_fcontext:
+.tars_make_fcontext:
 # endif
 #endif
     # save return address into R6
     mflr  %r6
 
-    # first arg of make_fcontext() == top address of context-stack
+    # first arg of tars_make_fcontext() == top address of context-stack
     # shift address in R3 to lower 16 byte boundary
     clrrdi  %r3, %r3, 4
 
@@ -107,7 +107,7 @@ make_fcontext:
     # including 64 byte of linkage + parameter area (R1 % 16 == 0)
     subi  %r3, %r3, 248
 
-    # third arg of make_fcontext() == address of context-function
+    # third arg of tars_make_fcontext() == address of context-function
     # entry point (ELFv2) or descriptor (ELFv1)
 #if _CALL_ELF == 2
     # save address of context-function entry point
@@ -164,12 +164,12 @@ finish:
     bl  _exit
     nop
 #if _CALL_ELF == 2
-	.size make_fcontext, .-make_fcontext
+	.size tars_make_fcontext, .-tars_make_fcontext
 #else
 # ifdef _CALL_LINUX
-	.size .make_fcontext, .-.L.make_fcontext
+	.size .tars_make_fcontext, .-.L.tars_make_fcontext
 # else
-	.size .make_fcontext, .-.make_fcontext
+	.size .tars_make_fcontext, .-.tars_make_fcontext
 # endif
 #endif
 

--- a/util/src/asm/make_ppc64_sysv_macho_gas.S
+++ b/util/src/asm/make_ppc64_sysv_macho_gas.S
@@ -66,12 +66,12 @@
  *                                                     *
 
 .text
-.globl _make_fcontext
-_make_fcontext:
+.globl _tars_make_fcontext
+_tars_make_fcontext:
     ; save return address into R6
     mflr  r6
 
-    ; first arg of make_fcontext() == top address of context-function
+    ; first arg of tars_make_fcontext() == top address of context-function
     ; shift address in R3 to lower 16 byte boundary
     clrrwi  r3, r3, 4
 
@@ -79,7 +79,7 @@ _make_fcontext:
     ; including 64 byte of linkage + parameter area (R1  16 == 0)
     subi  r3, r3, 248
 
-    ; third arg of make_fcontext() == address of context-function
+    ; third arg of tars_make_fcontext() == address of context-function
     stw  r5, 176(r3)
 
     ; set back-chain to zero

--- a/util/src/asm/make_ppc64_sysv_xcoff_gas.S
+++ b/util/src/asm/make_ppc64_sysv_xcoff_gas.S
@@ -4,16 +4,16 @@
       (See accompanying file LICENSE_1_0.txt or copy at
           http://www.boost.org/LICENSE_1_0.txt)
 */
-	.globl	make_fcontext[DS]
-	.globl .make_fcontext[PR]
+	.globl	tars_make_fcontext[DS]
+	.globl .tars_make_fcontext[PR]
 	.align 2 
-	.csect .make_fcontext[PR], 3
-	.globl _make_fcontext
-#._make_fcontext:
+	.csect .tars_make_fcontext[PR], 3
+	.globl _tars_make_fcontext
+#._tars_make_fcontext:
     # save return address into R6
     mflr  6
 
-    # first arg of make_fcontext() == top address of context-function
+    # first arg of tars_make_fcontext() == top address of context-function
     # shift address in R3 to lower 16 byte boundary
     clrrwi  3, 3, 4
 
@@ -21,7 +21,7 @@
     # including 64 byte of linkage + parameter area (R1 % 16 == 0)
     subi  3, 3, 248
 
-    # third arg of make_fcontext() == address of context-function
+    # third arg of tars_make_fcontext() == address of context-function
     stw  5, 176(3)
 
     # set back-chain to zero

--- a/util/src/asm/make_x86_64_ms_pe_gas.asm
+++ b/util/src/asm/make_x86_64_ms_pe_gas.asm
@@ -89,13 +89,13 @@
 .file	"make_x86_64_ms_pe_gas.asm"
 .text
 .p2align 4,,15
-.globl	make_fcontext
-.def	make_fcontext;	.scl	2;	.type	32;	.endef
-.seh_proc	make_fcontext
-make_fcontext:
+.globl	tars_make_fcontext
+.def	tars_make_fcontext;	.scl	2;	.type	32;	.endef
+.seh_proc	tars_make_fcontext
+tars_make_fcontext:
 .seh_endprologue
 
-    /* first arg of make_fcontext() == top of context-stack */
+    /* first arg of tars_make_fcontext() == top of context-stack */
     movq  %rcx, %rax
 
     /* shift address in RAX to lower 16 byte boundary */
@@ -106,13 +106,13 @@ make_fcontext:
     /* on context-function entry: (RSP -0x8) % 16 == 0 */
     leaq  -0x150(%rax), %rax
 
-    /* third arg of make_fcontext() == address of context-function */
+    /* third arg of tars_make_fcontext() == address of context-function */
     movq  %r8, 0x100(%rax)
 
-    /* first arg of make_fcontext() == top of context-stack */
+    /* first arg of tars_make_fcontext() == top of context-stack */
     /* save top address of context stack as 'base' */
     movq  %rcx, 0xc8(%rax)
-    /* second arg of make_fcontext() == size of context-stack */
+    /* second arg of tars_make_fcontext() == size of context-stack */
     /* negate stack size for LEA instruction (== substraction) */
     negq  %rdx
     /* compute bottom address of context stack (limit) */
@@ -138,7 +138,7 @@ make_fcontext:
     /* compute abs address of label trampoline */
     leaq  trampoline(%rip), %rcx
     /* save address of finish as return-address for context-function */
-    /* will be entered after jump_fcontext() first time */
+    /* will be entered after tars_jump_fcontext() first time */
     movq  %rcx, 0x118(%rax)
 
     /* compute abs address of label finish */
@@ -160,7 +160,7 @@ finish:
     /* 32byte shadow-space for _exit() */
     andq  $-32, %rsp
     /* 32byte shadow-space for _exit() are */
-    /* already reserved by make_fcontext() */
+    /* already reserved by tars_make_fcontext() */
     /* exit code is zero */
     xorq  %rcx, %rcx
     /* exit application */
@@ -171,4 +171,4 @@ finish:
 .def	_exit;	.scl	2;	.type	32;	.endef  /* standard C library function */
 
 .section .drectve
-.ascii " -export:\"make_fcontext\""
+.ascii " -export:\"tars_make_fcontext\""

--- a/util/src/asm/make_x86_64_ms_pe_masm.asm
+++ b/util/src/asm/make_x86_64_ms_pe_masm.asm
@@ -87,11 +87,11 @@ EXTERN  _exit:PROC
 .code
 
 ; generate function table entry in .pdata and unwind information in
-make_fcontext PROC EXPORT FRAME
+tars_make_fcontext PROC EXPORT FRAME
     ; .xdata for a function's structured exception handling unwind behavior
     .endprolog
 
-    ; first arg of make_fcontext() == top of context-stack
+    ; first arg of tars_make_fcontext() == top of context-stack
     mov  rax, rcx
 
     ; shift address in RAX to lower 16 byte boundary
@@ -102,14 +102,14 @@ make_fcontext PROC EXPORT FRAME
     ; on context-function entry: (RSP -0x8) % 16 == 0
     sub  rax, 0150h
 
-    ; third arg of make_fcontext() == address of context-function
+    ; third arg of tars_make_fcontext() == address of context-function
     ; stored in RBX
     mov  [rax+0100h], r8
 
-    ; first arg of make_fcontext() == top of context-stack
+    ; first arg of tars_make_fcontext() == top of context-stack
     ; save top address of context stack as 'base'
     mov  [rax+0c8h], rcx
-    ; second arg of make_fcontext() == size of context-stack
+    ; second arg of tars_make_fcontext() == size of context-stack
     ; negate stack size for LEA instruction (== substraction)
     neg  rdx
     ; compute bottom address of context stack (limit)
@@ -135,7 +135,7 @@ make_fcontext PROC EXPORT FRAME
     ; compute abs address of label trampoline
     lea  rcx, trampoline
     ; save address of trampoline as return-address for context-function
-    ; will be entered after calling jump_fcontext() first time
+    ; will be entered after calling tars_jump_fcontext() first time
     mov  [rax+0118h], rcx
 
     ; compute abs address of label finish
@@ -159,5 +159,5 @@ finish:
     ; exit application
     call  _exit
     hlt
-make_fcontext ENDP
+tars_make_fcontext ENDP
 END

--- a/util/src/asm/make_x86_64_sysv_elf_gas.S
+++ b/util/src/asm/make_x86_64_sysv_elf_gas.S
@@ -26,11 +26,11 @@
 
 .file "make_x86_64_sysv_elf_gas.S"
 .text
-.globl make_fcontext
-.type make_fcontext,@function
+.globl tars_make_fcontext
+.type tars_make_fcontext,@function
 .align 16
-make_fcontext:
-    /* first arg of make_fcontext() == top of context-stack */
+tars_make_fcontext:
+    /* first arg of tars_make_fcontext() == top of context-stack */
     movq  %rdi, %rax
 
     /* shift address in RAX to lower 16 byte boundary */
@@ -40,7 +40,7 @@ make_fcontext:
     /* on context-function entry: (RSP -0x8) % 16 == 0 */
     leaq  -0x40(%rax), %rax
 
-    /* third arg of make_fcontext() == address of context-function */
+    /* third arg of tars_make_fcontext() == address of context-function */
     /* stored in RBX */
     movq  %rdx, 0x28(%rax)
 
@@ -52,7 +52,7 @@ make_fcontext:
     /* compute abs address of label trampoline */
     leaq  trampoline(%rip), %rcx
     /* save address of trampoline as return-address for context-function */
-    /* will be entered after calling jump_fcontext() first time */
+    /* will be entered after calling tars_jump_fcontext() first time */
     movq  %rcx, 0x38(%rax)
 
     /* compute abs address of label finish */
@@ -76,7 +76,7 @@ finish:
     /* exit application */
     call  _exit@PLT
     hlt
-.size make_fcontext,.-make_fcontext
+.size tars_make_fcontext,.-tars_make_fcontext
 
 /* Mark that we don't need executable stack. */
 .section .note.GNU-stack,"",%progbits

--- a/util/src/asm/make_x86_64_sysv_macho_gas.S
+++ b/util/src/asm/make_x86_64_sysv_macho_gas.S
@@ -25,10 +25,10 @@
  ****************************************************************************************/
 
 .text
-.globl _make_fcontext
+.globl _tars_make_fcontext
 .align 8
-_make_fcontext:
-    /* first arg of make_fcontext() == top of context-stack */
+_tars_make_fcontext:
+    /* first arg of tars_make_fcontext() == top of context-stack */
     movq  %rdi, %rax
 
     /* shift address in RAX to lower 16 byte boundary */
@@ -38,7 +38,7 @@ _make_fcontext:
     /* on context-function entry: (RSP -0x8) % 16 == 0 */
     leaq  -0x40(%rax), %rax
 
-    /* third arg of make_fcontext() == address of context-function */
+    /* third arg of tars_make_fcontext() == address of context-function */
     /* stored in RBX */
     movq  %rdx, 0x28(%rax)
 
@@ -50,7 +50,7 @@ _make_fcontext:
     /* compute abs address of label trampoline */
     leaq  trampoline(%rip), %rcx
     /* save address of trampoline as return-address for context-function */
-    /* will be entered after calling jump_fcontext() first time */
+    /* will be entered after calling tars_jump_fcontext() first time */
     movq  %rcx, 0x38(%rax)
 
     /* compute abs address of label finish */

--- a/util/src/asm/ontop_arm64_aapcs_elf_gas.S
+++ b/util/src/asm/ontop_arm64_aapcs_elf_gas.S
@@ -54,9 +54,9 @@
 .file "ontop_arm64_aapcs_elf_gas.S"
 .text
 .align  2
-.global ontop_fcontext
-.type   ontop_fcontext, %function
-ontop_fcontext:
+.global tars_ontop_fcontext
+.type   tars_ontop_fcontext, %function
+tars_ontop_fcontext:
     # prepare stack for GP + FPU
     sub  sp, sp, #0xb0
 
@@ -108,6 +108,6 @@ ontop_fcontext:
 
     # jump to ontop-function
     ret x2
-.size   ontop_fcontext,.-ontop_fcontext
+.size   tars_ontop_fcontext,.-tars_ontop_fcontext
 # Mark that we don't need executable stack.
 .section .note.GNU-stack,"",%progbits

--- a/util/src/asm/ontop_arm64_aapcs_macho_gas.S
+++ b/util/src/asm/ontop_arm64_aapcs_macho_gas.S
@@ -52,9 +52,9 @@
  *******************************************************/
 
 .text
-.global _ontop_fcontext
+.global _tars_ontop_fcontext
 .balign 16
-_ontop_fcontext:
+_tars_ontop_fcontext:
     ; prepare stack for GP + FPU
     sub  sp, sp, #0xb0
 

--- a/util/src/asm/ontop_arm_aapcs_elf_gas.S
+++ b/util/src/asm/ontop_arm_aapcs_elf_gas.S
@@ -40,11 +40,11 @@
 
 .file "ontop_arm_aapcs_elf_gas.S"
 .text
-.globl ontop_fcontext
+.globl tars_ontop_fcontext
 .align 2
-.type ontop_fcontext,%function
+.type tars_ontop_fcontext,%function
 .syntax unified
-ontop_fcontext:
+tars_ontop_fcontext:
     @ save LR as PC
     push {lr}
     @ save hidden,V1-V8,LR
@@ -87,7 +87,7 @@ ontop_fcontext:
 
     @ jump to ontop-function
     bx  a4
-.size ontop_fcontext,.-ontop_fcontext
+.size tars_ontop_fcontext,.-tars_ontop_fcontext
 
 @ Mark that we don't need executable stack.
 .section .note.GNU-stack,"",%progbits

--- a/util/src/asm/ontop_arm_aapcs_macho_gas.S
+++ b/util/src/asm/ontop_arm_aapcs_macho_gas.S
@@ -39,9 +39,9 @@
  *******************************************************/
 
 .text
-.globl _ontop_fcontext
+.globl _tars_ontop_fcontext
 .align 2
-_ontop_fcontext:
+_tars_ontop_fcontext:
     @ save LR as PC
     push {lr}
     @ save hidden,V1-V8,LR

--- a/util/src/asm/ontop_arm_aapcs_pe_armasm.asm
+++ b/util/src/asm/ontop_arm_aapcs_pe_armasm.asm
@@ -26,9 +26,9 @@
 
     AREA |.text|, CODE
     ALIGN 4
-    EXPORT ontop_fcontext
+    EXPORT tars_ontop_fcontext
 
-ontop_fcontext PROC
+tars_ontop_fcontext PROC
     ; save LR as PC
     push {lr}
     ; save hidden,V1-V8,LR

--- a/util/src/asm/ontop_i386_ms_pe_gas.asm
+++ b/util/src/asm/ontop_i386_ms_pe_gas.asm
@@ -32,9 +32,9 @@
 .def	@feat.00;	.scl	3;	.type	0;	.endef
 .set    @feat.00,   1
 
-.globl	_ontop_fcontext
-.def	_ontop_fcontext;	.scl	2;	.type	32;	.endef
-_ontop_fcontext:
+.globl	_tars_ontop_fcontext
+.def	_tars_ontop_fcontext;	.scl	2;	.type	32;	.endef
+_tars_ontop_fcontext:
     /* prepare stack */
     leal  -0x2c(%esp), %esp
 
@@ -71,19 +71,19 @@ _ontop_fcontext:
     /* store ESP (pointing to context-data) in ECX */
     movl  %esp, %ecx
 
-    /* first arg of ontop_fcontext() == fcontext to jump to */
+    /* first arg of tars_ontop_fcontext() == fcontext to jump to */
     movl  0x30(%esp), %eax
 
 	/* pass parent fcontext_t */
 	movl  %ecx, 0x30(%eax)
 
-    /* second arg of ontop_fcontext() == data to be transferred */
+    /* second arg of tars_ontop_fcontext() == data to be transferred */
     movl  0x34(%esp), %ecx
 
 	/* pass data */
 	movl  %ecx, 0x34(%eax)
 
-    /* third arg of ontop_fcontext() == ontop-function */
+    /* third arg of tars_ontop_fcontext() == ontop-function */
     movl  0x38(%esp), %ecx
 
     /* restore ESP (pointing to context-data) from EDX */
@@ -128,4 +128,4 @@ _ontop_fcontext:
     jmp  *%ecx
 
 .section .drectve
-.ascii " -export:\"ontop_fcontext\""
+.ascii " -export:\"tars_ontop_fcontext\""

--- a/util/src/asm/ontop_i386_ms_pe_masm.asm
+++ b/util/src/asm/ontop_i386_ms_pe_masm.asm
@@ -24,7 +24,7 @@
 .model flat, c
 .code
 
-ontop_fcontext PROC EXPORT
+tars_ontop_fcontext PROC EXPORT
     ; prepare stack
     lea  esp, [esp-02ch]
 
@@ -63,19 +63,19 @@ ENDIF
     ; store ESP (pointing to context-data) in ECX
     mov  ecx, esp
 
-    ; first arg of ontop_fcontext() == fcontext to jump to
+    ; first arg of tars_ontop_fcontext() == fcontext to jump to
     mov  eax, [esp+030h]
 
 	; pass parent fcontext_t
 	mov  [eax+030h], ecx
 
-    ; second arg of ontop_fcontext() == data to be transferred
+    ; second arg of tars_ontop_fcontext() == data to be transferred
     mov  ecx, [esp+034h]
 
 	; pass data
 	mov  [eax+034h], ecx
 
-    ; third arg of ontop_fcontext() == ontop-function
+    ; third arg of tars_ontop_fcontext() == ontop-function
     mov  ecx, [esp+038h]
     
     ; restore ESP (pointing to context-data) from EAX
@@ -120,5 +120,5 @@ ENDIF
 
     ; jump to context
     jmp ecx
-ontop_fcontext ENDP
+tars_ontop_fcontext ENDP
 END

--- a/util/src/asm/ontop_i386_sysv_elf_gas.S
+++ b/util/src/asm/ontop_i386_sysv_elf_gas.S
@@ -26,10 +26,10 @@
 
 .file "ontop_i386_sysv_elf_gas.S"
 .text
-.globl ontop_fcontext
+.globl tars_ontop_fcontext
 .align 2
-.type ontop_fcontext,@function
-ontop_fcontext:
+.type tars_ontop_fcontext,@function
+tars_ontop_fcontext:
     leal  -0x18(%esp), %esp  /* prepare stack */
 
 #if !defined(BOOST_USE_TSX)
@@ -45,19 +45,19 @@ ontop_fcontext:
     /* store ESP (pointing to context-data) in ECX */
     movl  %esp, %ecx
 
-    /* first arg of ontop_fcontext() == fcontext to jump to */
+    /* first arg of tars_ontop_fcontext() == fcontext to jump to */
     movl  0x20(%esp), %eax
 
     /* pass parent fcontext_t */
     movl  %ecx, 0x20(%eax)
 
-    /* second arg of ontop_fcontext() == data to be transferred */
+    /* second arg of tars_ontop_fcontext() == data to be transferred */
     movl  0x24(%esp), %ecx
 
     /* pass data */
     movl %ecx, 0x24(%eax)
 
-    /* third arg of ontop_fcontext() == ontop-function */
+    /* third arg of tars_ontop_fcontext() == ontop-function */
     movl  0x28(%esp), %ecx
 
     /* restore ESP (pointing to context-data) from EAX */
@@ -84,7 +84,7 @@ ontop_fcontext:
 
     /* jump to context */
     jmp *%ecx
-.size ontop_fcontext,.-ontop_fcontext
+.size tars_ontop_fcontext,.-tars_ontop_fcontext
 
 /* Mark that we don't need executable stack.  */
 .section .note.GNU-stack,"",%progbits

--- a/util/src/asm/ontop_i386_sysv_macho_gas.S
+++ b/util/src/asm/ontop_i386_sysv_macho_gas.S
@@ -25,9 +25,9 @@
  ****************************************************************************************/
 
 .text
-.globl _ontop_fcontext
+.globl _tars_ontop_fcontext
 .align 2
-_ontop_fcontext:
+_tars_ontop_fcontext:
     leal  -0x18(%esp), %esp  /* prepare stack */
 
 #if !defined(BOOST_USE_TSX)
@@ -43,19 +43,19 @@ _ontop_fcontext:
     /* store ESP (pointing to context-data) in ECX */
     movl  %esp, %ecx
 
-    /* first arg of ontop_fcontext() == fcontext to jump to */
+    /* first arg of tars_ontop_fcontext() == fcontext to jump to */
     movl  0x1c(%esp), %eax
 
     /* pass parent fcontext_t */
     movl  %ecx, 0x1c(%eax)
 
-    /* second arg of ontop_fcontext() == data to be transferred */
+    /* second arg of tars_ontop_fcontext() == data to be transferred */
     movl  0x20(%esp), %ecx
 
     /* pass data */
     movl %ecx, 0x20(%eax)
 
-    /* third arg of ontop_fcontext() == ontop-function */
+    /* third arg of tars_ontop_fcontext() == ontop-function */
     movl  0x24(%esp), %ecx
 
     /* restore ESP (pointing to context-data) from EAX */

--- a/util/src/asm/ontop_mips32_o32_elf_gas.S
+++ b/util/src/asm/ontop_mips32_o32_elf_gas.S
@@ -40,11 +40,11 @@
 
 .file "ontop_mips32_o32_elf_gas.S"
 .text
-.globl ontop_fcontext
+.globl tars_ontop_fcontext
 .align 2
-.type ontop_fcontext,@function
-.ent ontop_fcontext
-ontop_fcontext:
+.type tars_ontop_fcontext,@function
+.ent tars_ontop_fcontext
+tars_ontop_fcontext:
     # reserve space on stack
     addiu $sp, $sp, -96
 
@@ -113,8 +113,8 @@ ontop_fcontext:
 
     # jump to context
     jr  $t9
-.end ontop_fcontext
-.size ontop_fcontext, .-ontop_fcontext
+.end tars_ontop_fcontext
+.size tars_ontop_fcontext, .-tars_ontop_fcontext
 
 /* Mark that we don't need executable stack.  */
 .section .note.GNU-stack,"",%progbits

--- a/util/src/asm/ontop_ppc32_sysv_elf_gas.S
+++ b/util/src/asm/ontop_ppc32_sysv_elf_gas.S
@@ -52,12 +52,12 @@
 
 .file "ontop_ppc32_sysv_elf_gas.S"
 .text
-.globl ontop_fcontext
+.globl tars_ontop_fcontext
 .align 2
-.type ontop_fcontext,@function
-ontop_fcontext:
-    # Linux: ontop_fcontext( hidden transfer_t * R3, R4, R5, R6)
-    # Other: transfer_t R3:R4 = jump_fcontext( R3, R4, R5)
+.type tars_ontop_fcontext,@function
+tars_ontop_fcontext:
+    # Linux: tars_ontop_fcontext( hidden transfer_t * R3, R4, R5, R6)
+    # Other: transfer_t R3:R4 = tars_jump_fcontext( R3, R4, R5)
 
     mflr  %r0  # return address from LR
     mffs  %f0  # FPSCR
@@ -186,8 +186,8 @@ ontop_fcontext:
     # see tail_ppc32_sysv_elf_gas.cpp
     # Linux: fcontext_ontop_tail( hidden transfer_t * R3, R4, R5, R6, R7)
     # Other: transfer_t R3:R4 = fcontext_ontop_tail( R3, R4, R5, R6)
-    b ontop_fcontext_tail
-.size ontop_fcontext, .-ontop_fcontext
+    b tars_ontop_fcontext_tail
+.size tars_ontop_fcontext, .-tars_ontop_fcontext
 
 /* Mark that we don't need executable stack.  */
 .section .note.GNU-stack,"",%progbits

--- a/util/src/asm/ontop_ppc32_sysv_macho_gas.S
+++ b/util/src/asm/ontop_ppc32_sysv_macho_gas.S
@@ -74,9 +74,9 @@
  *******************************************************/
 
 .text
-.globl _ontop_fcontext
+.globl _tars_ontop_fcontext
 .align 2
-_ontop_fcontext:
+_tars_ontop_fcontext:
     # reserve space on stack
     subi  r1, r1, 244
 

--- a/util/src/asm/ontop_ppc32_sysv_xcoff_gas.S
+++ b/util/src/asm/ontop_ppc32_sysv_xcoff_gas.S
@@ -72,13 +72,13 @@
  *  -------------------------------------------------  *
  *                                                     *
  *******************************************************/
-.globl .ontop_fcontext
-.globl  ontop_fcontext[DS]
+.globl .tars_ontop_fcontext
+.globl  tars_ontop_fcontext[DS]
 .align 2 
-.csect	ontop_fcontext[DS]
-ontop_fcontext:
-  .long	.ontop_fcontext
-.ontop_fcontext:
+.csect	tars_ontop_fcontext[DS]
+tars_ontop_fcontext:
+  .long	.tars_ontop_fcontext
+.tars_ontop_fcontext:
     # reserve space on stack
     subi  r1, r1, 244
 

--- a/util/src/asm/ontop_ppc64_sysv_elf_gas.S
+++ b/util/src/asm/ontop_ppc64_sysv_elf_gas.S
@@ -67,33 +67,33 @@
  *******************************************************/
 
 .file "ontop_ppc64_sysv_elf_gas.S"
-.globl ontop_fcontext
+.globl tars_ontop_fcontext
 #if _CALL_ELF == 2
 	.text
 	.align 2
-ontop_fcontext:
-        addis   %r2, %r12, .TOC.-ontop_fcontext@ha
-        addi    %r2, %r2, .TOC.-ontop_fcontext@l
-        .localentry ontop_fcontext, . - ontop_fcontext
+tars_ontop_fcontext:
+        addis   %r2, %r12, .TOC.-tars_ontop_fcontext@ha
+        addi    %r2, %r2, .TOC.-tars_ontop_fcontext@l
+        .localentry tars_ontop_fcontext, . - tars_ontop_fcontext
 #else
 	.section ".opd","aw"
 	.align 3
-ontop_fcontext:
+tars_ontop_fcontext:
 # ifdef _CALL_LINUX
-        .quad   .L.ontop_fcontext,.TOC.@tocbase,0
-        .type   ontop_fcontext,@function
+        .quad   .L.tars_ontop_fcontext,.TOC.@tocbase,0
+        .type   tars_ontop_fcontext,@function
         .text
         .align 2
-.L.ontop_fcontext:
+.L.tars_ontop_fcontext:
 # else
-        .hidden .ontop_fcontext
-        .globl  .ontop_fcontext
-        .quad   .ontop_fcontext,.TOC.@tocbase,0
-        .size   ontop_fcontext,24
-        .type   .ontop_fcontext,@function
+        .hidden .tars_ontop_fcontext
+        .globl  .tars_ontop_fcontext
+        .quad   .tars_ontop_fcontext,.TOC.@tocbase,0
+        .size   tars_ontop_fcontext,24
+        .type   .tars_ontop_fcontext,@function
         .text
         .align 2
-.ontop_fcontext:
+.tars_ontop_fcontext:
 # endif
 #endif
     # reserve space on stack
@@ -209,7 +209,7 @@ return_to_ctx:
     bctr
 
 #if _CALL_ELF == 2
-	.size ontop_fcontext, .-ontop_fcontext
+	.size tars_ontop_fcontext, .-tars_ontop_fcontext
 #else
 use_entry_arg:
     # compute return-value struct address
@@ -233,9 +233,9 @@ use_entry_arg:
 
     b  return_to_ctx
 # ifdef _CALL_LINUX
-	.size .ontop_fcontext, .-.L.ontop_fcontext
+	.size .tars_ontop_fcontext, .-.L.tars_ontop_fcontext
 # else
-	.size .ontop_fcontext, .-.ontop_fcontext
+	.size .tars_ontop_fcontext, .-.tars_ontop_fcontext
 # endif
 #endif
 

--- a/util/src/asm/ontop_ppc64_sysv_macho_gas.S
+++ b/util/src/asm/ontop_ppc64_sysv_macho_gas.S
@@ -68,9 +68,9 @@
 
 .text
 .align 2
-.globl _ontop_fcontext
+.globl _tars_ontop_fcontext
 
-_ontop_fcontext:
+_tars_ontop_fcontext:
     ; reserve space on stack
     subi  r1, r1, 184
 

--- a/util/src/asm/ontop_ppc64_sysv_xcoff_gas.S
+++ b/util/src/asm/ontop_ppc64_sysv_xcoff_gas.S
@@ -1,6 +1,6 @@
 .align 2
-.globl .ontop_fcontext
-.ontop_fcontext:
+.globl .tars_ontop_fcontext
+.tars_ontop_fcontext:
     # reserve space on stack
     subi  1, 1, 184
 

--- a/util/src/asm/ontop_x86_64_ms_pe_gas.asm
+++ b/util/src/asm/ontop_x86_64_ms_pe_gas.asm
@@ -89,10 +89,10 @@
 .file	"ontop_x86_64_ms_pe_gas.asm"
 .text
 .p2align 4,,15
-.globl	ontop_fcontext
-.def	ontop_fcontext;	.scl	2;	.type	32;	.endef
-.seh_proc	ontop_fcontext
-ontop_fcontext:
+.globl	tars_ontop_fcontext
+.def	tars_ontop_fcontext;	.scl	2;	.type	32;	.endef
+.seh_proc	tars_ontop_fcontext
+tars_ontop_fcontext:
 .seh_endprologue
 
     leaq  -0x118(%rsp), %rsp /* prepare stack */
@@ -208,4 +208,4 @@ ontop_fcontext:
 .seh_endproc
 
 .section .drectve
-.ascii " -export:\"ontop_fcontext\""
+.ascii " -export:\"tars_ontop_fcontext\""

--- a/util/src/asm/ontop_x86_64_ms_pe_masm.asm
+++ b/util/src/asm/ontop_x86_64_ms_pe_masm.asm
@@ -84,7 +84,7 @@
 
 .code
 
-ontop_fcontext PROC EXPORT FRAME
+tars_ontop_fcontext PROC EXPORT FRAME
     .endprolog
 
     ; prepare stack
@@ -203,5 +203,5 @@ ENDIF
 
     ; indirect jump to context
     jmp  r9
-ontop_fcontext ENDP
+tars_ontop_fcontext ENDP
 END

--- a/util/src/asm/ontop_x86_64_sysv_elf_gas.S
+++ b/util/src/asm/ontop_x86_64_sysv_elf_gas.S
@@ -26,10 +26,10 @@
 
 .file "ontop_x86_64_sysv_elf_gas.S"
 .text
-.globl ontop_fcontext
-.type ontop_fcontext,@function
+.globl tars_ontop_fcontext
+.type tars_ontop_fcontext,@function
 .align 16
-ontop_fcontext:
+tars_ontop_fcontext:
     /* preserve ontop-function in R8 */
     movq  %rdx, %r8
 
@@ -88,7 +88,7 @@ ontop_fcontext:
 
     /* indirect jump to context */
     jmp  *%r8
-.size ontop_fcontext,.-ontop_fcontext
+.size tars_ontop_fcontext,.-tars_ontop_fcontext
 
 /* Mark that we don't need executable stack.  */
 .section .note.GNU-stack,"",%progbits

--- a/util/src/asm/ontop_x86_64_sysv_macho_gas.S
+++ b/util/src/asm/ontop_x86_64_sysv_macho_gas.S
@@ -25,9 +25,9 @@
  ****************************************************************************************/
 
 .text
-.globl _ontop_fcontext
+.globl _tars_ontop_fcontext
 .align 8
-_ontop_fcontext:
+_tars_ontop_fcontext:
     /* preserve ontop-function in R8 */
     movq  %rdx, %r8
 

--- a/util/src/tc_coroutine.cpp
+++ b/util/src/tc_coroutine.cpp
@@ -245,9 +245,9 @@ void TC_CoroutineInfo::registerFunc(const std::function<void ()>& callback)
 
     _init_func.args     = this;
 
-	fcontext_t ctx      = make_fcontext(_stack_ctx.sp, _stack_ctx.size, TC_CoroutineInfo::corotineEntry);
+	fcontext_t ctx      = tars_make_fcontext(_stack_ctx.sp, _stack_ctx.size, TC_CoroutineInfo::corotineEntry);
 
-	transfer_t tf       = jump_fcontext(ctx, this);
+	transfer_t tf       = tars_jump_fcontext(ctx, this);
 
 	//实际的ctx
 	this->setCtx(tf.fctx);
@@ -260,7 +260,7 @@ void TC_CoroutineInfo::corotineEntry(transfer_t tf)
     auto    func  = coro->_init_func.coroFunc;
     void*    args = coro->_init_func.args;
 
-	transfer_t t = jump_fcontext(tf.fctx, NULL);
+	transfer_t t = tars_jump_fcontext(tf.fctx, NULL);
 
 	//拿到自己的协程堆栈, 当前协程结束以后, 好跳转到main
 	coro->_scheduler->setMainCtx(t.fctx);
@@ -688,7 +688,7 @@ void TC_CoroutineScheduler::switchCoro(TC_CoroutineInfo *to)
     //跳转到to协程
     _currentCoro = to;
 
-	transfer_t t = jump_fcontext(to->getCtx(), NULL);
+	transfer_t t = tars_jump_fcontext(to->getCtx(), NULL);
 
 	//并保存协程堆栈
 	to->setCtx(t.fctx);


### PR DESCRIPTION
在使用时与其他库(比如libgo)一起链接，会遇到多个库引用不同版本boost fcontext的问题产生冲突导致程序崩溃，修改xxx_fcontext名称，避免与其他使用boost fcontext的库产生冲突