### PR TITLE
fix: compilation error of tc_rbtree on Ubuntu `24.04`

### DIFF
--- a/util/include/util/tc_rbtree.h
+++ b/util/include/util/tc_rbtree.h
@@ -19,8 +19,8 @@
 #include <string>
 #include <cassert>
 #include <functional>
+#include <cstdint>
 #include "util/tc_platform.h"
-
 #include "util/tc_ex.h"
 #include "util/tc_pack.h"
 #include "util/tc_mem_chunk.h"


### PR DESCRIPTION
On Ubuntu `24.04`, a compilation error occurs when running the `make -j4` command, whereas no issues arise on Ubuntu `20.04`. This problem is due to a missing `#include <cstdint>` directive in `util/include/util/tc_rbtree.h`, likely caused by changes in the g++ version on Ubuntu `24.04`.

![5d51346aa4c30f4f0e00a476c0f6059d](https://github.com/user-attachments/assets/e23cb97d-b515-4d9f-b5de-b4a2d1141df9)
